### PR TITLE
Add changes on comments and change the names of two method

### DIFF
--- a/examples/booking_app/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/booking_app/ios/Runner.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/examples/booking_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/examples/booking_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/booking_app/lib/feature_hotel/search/ui_components/hotel_sort_page.dart
+++ b/examples/booking_app/lib/feature_hotel/search/ui_components/hotel_sort_page.dart
@@ -87,7 +87,7 @@ class _HotelSortPageState extends State<HotelSortPage> {
           child: Chip(
             labelStyle: ChipTheme.of(context)
                 .labelStyle
-                .copyWith(color: selected == id ? Colors.white : Colors.black),
+                ?.copyWith(color: selected == id ? Colors.white : Colors.black),
             label: Text(name),
             backgroundColor:
                 selected == id ? Theme.of(context).colorScheme.secondary : null,

--- a/packages/rx_bloc/lib/src/result_extensions.dart
+++ b/packages/rx_bloc/lib/src/result_extensions.dart
@@ -53,10 +53,10 @@ extension ResultMapStream<E> on Stream<Result<E>> {
   /// Example:
   /// ```
   /// Result<String> result = Stream.value(Result.success(10))
-  ///   .mapResultStream((value) => value * 10)
-  ///   .mapResultStream((value) => value.toString()); // Result.success('100')
+  ///   .mapResult((value) => value * 10)
+  ///   .mapResult((value) => value.toString()); // Result.success('100')
   /// ```
-  Stream<Result<T>> mapResultStream<T>(T Function(E) mapSuccess) => map(
+  Stream<Result<T>> mapResult<T>(T Function(E) mapSuccess) => map(
         (result) => result.mapResult(mapSuccess),
       );
 
@@ -69,10 +69,10 @@ extension ResultMapStream<E> on Stream<Result<E>> {
   /// Example:
   /// ```
   /// Result<String> result = Stream.value(Result.success(10))
-  ///   .asyncMapResultStream((value) async => value * 10)
-  ///   .asyncMapResultStream((value) async => value.toString()); // Result.success('100')
+  ///   .asyncMapResult((value) async => value * 10)
+  ///   .asyncMapResult((value) async => value.toString()); // Result.success('100')
   /// ```
-  Stream<Result<T>> asyncMapResultStream<T>(Future<T> Function(E) mapSuccess) =>
+  Stream<Result<T>> asyncMapResult<T>(Future<T> Function(E) mapSuccess) =>
       asyncMap(
         (result) => result.asyncMapResult(mapSuccess),
       );

--- a/packages/rx_bloc/lib/src/result_extensions.dart
+++ b/packages/rx_bloc/lib/src/result_extensions.dart
@@ -7,8 +7,10 @@ extension ResultMapStreamX<E> on Stream<E> {
   ///
   /// Example:
   /// ```
-  /// ResultSuccess<int> result = Stream.value(10).mapToResult();
-  /// ResultSuccess<int> result = Stream.value(10).mapToResult((value) => value * 10);
+  /// ResultSuccess<int> result = Stream.value(10)
+  ///   .mapToResult(); // Result.success('10')
+  /// ResultSuccess<int> result = Stream.value(10)
+  ///   .mapToResult((value) => value * 10); // Result.success('100')
   /// ```
   Stream<Result<E>> mapToResult([E Function(E)? mapper]) => map((data) {
         if (mapper != null) {
@@ -18,7 +20,7 @@ extension ResultMapStreamX<E> on Stream<E> {
         return Result<E>.success(data);
       });
 
-  /// Map the give stream to a new one [Result] stream,
+  /// Map the give stream to a new [Result] one,
   /// as combining it with another [stream].
   ///
   /// Use [mapSuccess] to map the current stream with the
@@ -44,41 +46,41 @@ extension ResultMapStreamX<E> on Stream<E> {
 
 extension ResultMapStream<E> on Stream<Result<E>> {
   /// Map the current [Result] stream to a new [Result] one,
-  /// which could by from different type.
+  /// which could be from a different type.
   ///
   /// Use the [mapSuccess] to map the success from the current stream to the
   /// result stream.
   /// Example:
   /// ```
   /// Result<String> result = Stream.value(Result.success(10))
-  ///   .mapResult((value) => value * 10)
-  ///   .mapResult((value) => value.toString()); // Result.success('100')
+  ///   .mapResultStream((value) => value * 10)
+  ///   .mapResultStream((value) => value.toString()); // Result.success('100')
   /// ```
-  Stream<Result<T>> mapResult<T>(T Function(E) mapSuccess) => map(
+  Stream<Result<T>> mapResultStream<T>(T Function(E) mapSuccess) => map(
         (result) => result.mapResult(mapSuccess),
       );
 
   /// Map the current [Result] stream to a new [Result] one,
-  /// which could by from different type.
+  /// which could be from a different type.
   ///
   /// Use the [mapSuccess] callback to map the success from the current stream
-  /// to the result stream in async manner.
+  /// to the result stream in an async manner.
   ///
   /// Example:
   /// ```
   /// Result<String> result = Stream.value(Result.success(10))
-  ///   .asyncMapResult((value) async => value * 10)
-  ///   .asyncMapResult((value) async => value.toString()); // Result.success('100')
+  ///   .asyncMapResultStream((value) async => value * 10)
+  ///   .asyncMapResultStream((value) async => value.toString()); // Result.success('100')
   /// ```
-  Stream<Result<T>> asyncMapResult<T>(Future<T> Function(E) mapSuccess) =>
+  Stream<Result<T>> asyncMapResultStream<T>(Future<T> Function(E) mapSuccess) =>
       asyncMap(
         (result) => result.asyncMapResult(mapSuccess),
       );
 }
 
 extension ResultMap<E> on Result<E> {
-  /// Map the current [Result] to a new [Result],
-  /// which could be from different type.
+  /// Map the current [Result] to a new [Result] one,
+  /// which could be from a different type.
   Future<Result<T>> asyncMapResult<T>(Future<T> Function(E) mapSuccess) async {
     final that = this;
 
@@ -89,8 +91,8 @@ extension ResultMap<E> on Result<E> {
     return _mapResultToErrorOrLoading<T>();
   }
 
-  /// Map the current [Result] to a new [Result],
-  /// which could be from different type.
+  /// Map the current [Result] to a new [Result] one,
+  /// which could be from a different type.
   Result<T> mapResult<T>(T Function(E) mapSuccess) {
     final that = this;
 

--- a/packages/rx_bloc/test/result_extensions_test.dart
+++ b/packages/rx_bloc/test/result_extensions_test.dart
@@ -38,8 +38,8 @@ void main() {
           Result.success(10),
           Result.error(Exception('1'))
         ])
-            .mapResult((value) => value * 10)
-            .asyncMapResult((value) async => value.toString()),
+            .mapResultStream((value) => value * 10)
+            .asyncMapResultStream((value) async => value.toString()),
         emitsInOrder(<Result<String>>[
           Result.loading(),
           Result.success('100'),

--- a/packages/rx_bloc/test/result_extensions_test.dart
+++ b/packages/rx_bloc/test/result_extensions_test.dart
@@ -38,8 +38,8 @@ void main() {
           Result.success(10),
           Result.error(Exception('1'))
         ])
-            .mapResultStream((value) => value * 10)
-            .asyncMapResultStream((value) async => value.toString()),
+            .mapResult((value) => value * 10)
+            .asyncMapResult((value) async => value.toString()),
         emitsInOrder(<Result<String>>[
           Result.loading(),
           Result.success('100'),

--- a/packages/rx_bloc_list/lib/src/extensions/identifiable_extensions.dart
+++ b/packages/rx_bloc_list/lib/src/extensions/identifiable_extensions.dart
@@ -28,7 +28,7 @@ extension ListIdentifiableUtils<T extends Identifiable> on List<T> {
     }
   }
 
-  /// Return a new list with removed first occurrence of [identifiable] from this list.
+  /// Return a new list with removed all occurrence of [identifiable] from this list.
   List<T> removedIdentifiable(Identifiable identifiable) {
     final list = [...this];
     list.removeWhere((element) => element.id == identifiable.id);
@@ -38,9 +38,9 @@ extension ListIdentifiableUtils<T extends Identifiable> on List<T> {
 
   /// Return a new list with the given [list] merged into the current list.
   ///
-  /// 1. In case that any of the provided [T] it not part of the current
+  /// 1. In case that any of the provided [T] is not part of the current
   /// list, the returned result will include the entities from the provided [T]
-  /// 2. [addIfNotExist] In case that any of the provided [T] it's not part of the
+  /// 2. [addIfNotExist] In case that any of the provided [T] is not part of the
   /// current list it will be added at the end of the list.
   List<T> mergeWith(
     List<T> list, {
@@ -98,7 +98,7 @@ extension ModelManageEvents<E extends Identifiable> on Stream<E> {
   /// )
   /// ```
   ///
-  /// 3. The stream value won't be neither merged or removed from the [list] value
+  /// 3. The stream value won't be neither merged nor removed from the [list] value
   /// ```
   /// objectStream.identifiableWithLatestFrom(
   ///     listStream,


### PR DESCRIPTION
Change some comments. Change the name of two methods to avoid confusion with the other methods with the same names in the same file.