### PR TITLE
bump analyzer version

### DIFF
--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rx_bloc_generator
 description: Code generator for rx_bloc that makes your BloC zero-boilerplate.
-version: 6.0.0
+version: 6.0.1
 repository: https://github.com/Prime-Holding/rx_bloc/tree/master/packages/rx_bloc_generator
 issue_tracker: https://github.com/Prime-Holding/rx_bloc/issues
 homepage: https://www.primeholding.com/
@@ -9,7 +9,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  analyzer: ">=3.0.0 <=5.0.0"
+  analyzer: ">=3.0.0 <=6.0.0"
   build: ^2.3.0
   code_builder: ^4.3.0
   collection: ^1.16.0


### PR DESCRIPTION
Bump max analyzer version to 6.0.0

[issue 379](https://github.com/Prime-Holding/rx_bloc/issues/379)