### PR TITLE
replace test io util with openapi file util

### DIFF
--- a/extensions/intellij/intellij_generator_plugin/build.gradle
+++ b/extensions/intellij/intellij_generator_plugin/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group 'com.rx_bloc'
-version '3.0.2'
+version '3.0.4'
 
 
 apply plugin: 'org.jetbrains.intellij'
@@ -53,6 +53,9 @@ jacocoTestReport {
 patchPluginXml {
     changeNotes """
      <ul>
+      <li>
+     v.3.0.4 - intellij ce - compatibility fix
+     </li>
       <li>
      v.3.0.2 - separate state mock initialization
      </li>

--- a/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/BootstrapSingleTestAction.kt
+++ b/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/BootstrapSingleTestAction.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.testFramework.VfsTestUtil
 import com.primeholding.rxbloc_generator_plugin.generator.RxTestGeneratorBase
 import com.primeholding.rxbloc_generator_plugin.generator.parser.Utils
 import com.primeholding.rxbloc_generator_plugin.intention_action.BlocWrapWithIntentionAction
@@ -147,9 +146,9 @@ class BootstrapSingleTestAction : AnAction() {
 
                 return null
             }
-
-            VfsTestUtil.overwriteTestData(destinationFile, value)
-            return VfsUtil.findFileByIoFile(File(destinationFile), true)
+            val ioFile = File(destinationFile)
+            Utils.writeToFile(ioFile, value)
+            return VfsUtil.findFileByIoFile(ioFile, true)
         }
         return null
     }
@@ -327,17 +326,19 @@ class BootstrapSingleTestAction : AnAction() {
 
                 return
             }
-            val newFile = VfsTestUtil.createFile(
-                Utils.baseDir(project.basePath!!),
+            val newFile = Utils.createFile(
                 newFilePath
             )
-            BootstrapTestsAction.writeBlockTest(
-                newFile,
-                bloc,
-                projectName = Utils.baseDir(project.basePath!!).name,
-                includeDiMocks = true
-            )
-            FileEditorManager.getInstance(project).openFile(newFile, false)
+            newFile?.let {
+                BootstrapTestsAction.writeBlockTest(
+                    it,
+                    bloc,
+                    projectName = Utils.baseDir(project.basePath!!).name,
+                    includeDiMocks = true
+                )
+                FileEditorManager.getInstance(project).openFile(newFile, false)
+            }
+
         }
     }
 

--- a/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/BootstrapTestsAction.kt
+++ b/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/BootstrapTestsAction.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.testFramework.VfsTestUtil
 import com.primeholding.rxbloc_generator_plugin.generator.parser.TestableClass
 import com.primeholding.rxbloc_generator_plugin.generator.parser.Utils
 import com.primeholding.rxbloc_generator_plugin.ui.ChooseBlocsDialog
@@ -205,7 +204,7 @@ class BootstrapTestsAction : AnAction() {
         val test = com.primeholding.rxbloc_generator_plugin.generator.components.RxTestBlocMockGenerator(
             name = bloc.file.name.replace(".dart", ""), projectName = projectName, bloc = bloc
         )
-        VfsTestUtil.overwriteTestData(testFile.path, test.generate())
+        Utils.writeToFile(testFile.path, test.generate())
     }
 
     companion object {
@@ -214,14 +213,14 @@ class BootstrapTestsAction : AnAction() {
             val test = com.primeholding.rxbloc_generator_plugin.generator.components.RxTestBlocGoldenGenerator(
                 name = bloc.file.name.replace(".dart", ""), projectName = projectName, bloc = bloc
             )
-            VfsTestUtil.overwriteTestData(testFile.path, test.generate())
+            Utils.writeToFile(testFile.path, test.generate())
         }
 
         fun writeTestFactory(testFile: VirtualFile, bloc: TestableClass, projectName: String) {
             val test = com.primeholding.rxbloc_generator_plugin.generator.components.RxTestBlocFactoryGenerator(
                 name = bloc.file.name.replace(".dart", ""), projectName = projectName, bloc = bloc
             )
-            VfsTestUtil.overwriteTestData(testFile.path, test.generate())
+            Utils.writeToFile(testFile.path, test.generate())
 
         }
 
@@ -237,7 +236,7 @@ class BootstrapTestsAction : AnAction() {
                 bloc = bloc,
                 includeDiMocks = includeDiMocks
             )
-            VfsTestUtil.overwriteTestData(testFile.path, test.generate())
+            Utils.writeToFile(testFile.path, test.generate())
         }
 
     }

--- a/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/GenerateRxBlocFeatureAction.kt
+++ b/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/GenerateRxBlocFeatureAction.kt
@@ -11,11 +11,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.testFramework.VfsTestUtil
 import com.primeholding.rxbloc_generator_plugin.action.GenerateRxBlocDialog.RoutingIntegration
 import com.primeholding.rxbloc_generator_plugin.generator.RxBlocFeatureGeneratorFactory
 import com.primeholding.rxbloc_generator_plugin.generator.RxGeneratorBase
 import com.primeholding.rxbloc_generator_plugin.generator.components.RxPageGenerator
+import com.primeholding.rxbloc_generator_plugin.generator.parser.Utils
 import java.io.File
 
 
@@ -140,10 +140,10 @@ class GenerateRxBlocFeatureAction : AnAction(), GenerateRxBlocDialog.Listener {
 
             if (file.exists()) {
                 val text = file.readText()
-                VfsTestUtil.overwriteTestData(filePath, "${text}${newRoute}")
+                Utils.writeToFile(filePath, "${text}${newRoute}")
             } else {
                 partRoutes = "part 'routes/routes.dart';"
-                VfsTestUtil.overwriteTestData(
+                Utils.writeToFile(
                     filePath,
                     """
 part of '../router.dart';
@@ -164,7 +164,7 @@ $newRoute""".trimIndent()
             val router = File(routerPath)
             if (router.exists()) {
                 val text = editRouter(router.readText(), subPart, name, partRoutes)
-                VfsTestUtil.overwriteTestData(routerPath, text)
+                Utils.writeToFile(routerPath, text)
             }
 
 
@@ -173,14 +173,14 @@ $newRoute""".trimIndent()
             file = File(filePath)
             if (file.exists()) {
                 val text = editRoutesPath(File(file.path).readText(), featureFieldCase)
-                VfsTestUtil.overwriteTestData(file.path, text)
+                Utils.writeToFile(file.path, text)
             }
             filePath =
                 "${it.basePath}${File.separator}lib${File.separator}lib_router${File.separator}models${File.separator}route_model.dart"
             file = File(filePath)
             if (file.exists()) {
                 val text = editRouteModel(File(file.path).readText(), featureFieldCase)
-                VfsTestUtil.overwriteTestData(file.path, text)
+                Utils.writeToFile(file.path, text)
             }
 
             filePath =
@@ -188,7 +188,7 @@ $newRoute""".trimIndent()
             file = File(filePath)
             if (file.exists()) {
                 val text = editRoutePermissions(File(file.path).readText(), featureFieldCase, featureCamelCase)
-                VfsTestUtil.overwriteTestData(file.path, text)
+                Utils.writeToFile(file.path, text)
             }
 
             filePath =
@@ -196,7 +196,7 @@ $newRoute""".trimIndent()
             file = File(filePath)
             if (file.exists()) {
                 val text = editPermissionsController(File(file.path).readText(), featureCamelCase)
-                VfsTestUtil.overwriteTestData(file.path, text)
+                Utils.writeToFile(file.path, text)
             }
         }
     }
@@ -275,7 +275,7 @@ class ${featureCamelCase}Route extends GoRouteData implements RouteDataModel {
         }
 
         val file = directory.createChildData(this, fileName)
-        VfsTestUtil.overwriteTestData(file.path, fixSubPaths(generator.generate(), directory.parent))
+        Utils.writeToFile(file.path, fixSubPaths(generator.generate(), directory.parent))
         return file
     }
 

--- a/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/generator/parser/Utils.kt
+++ b/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/generator/parser/Utils.kt
@@ -1,5 +1,7 @@
 package com.primeholding.rxbloc_generator_plugin.generator.parser
 
+import com.intellij.openapi.util.io.FileUtil
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.primeholding.rxbloc_generator_plugin.intention_action.BlocWrapWithIntentionAction
@@ -377,6 +379,19 @@ class Utils {
             return VfsUtil.findFileByIoFile(File(basePath), false)!!
         }
 
+        fun writeToFile(ioFile: String, value: String) {
+            writeToFile(File(ioFile), value)
+        }
+
+        fun writeToFile(ioFile: File, value: String) {
+            FileUtil.writeToFile(ioFile, value)
+        }
+
+        fun createFile(newFilePath: String): VirtualFile? {
+
+            val newFile = File(newFilePath)
+            return LocalFileSystem.getInstance().findFileByIoFile(newFile)
+        }
     }
 
 


### PR DESCRIPTION
Replaced calls to testFramework.VfsTestUtil, with openapi.vfs/openapi.util.io APIs. 

The reason for this is compatibility of the Plugin with IntelliJ IDE - Community Edition. 
Steps to reproduce 
- install IntelliJ IDE CE 
- install the rx bloc plugin (and all other required for flutter project - flutter, dart, etc) 
- open a flutter project
- try to create new feature 
-- with the current build it fails

Steps to check if it is fixed 
-- install the plugin on IntelliJ IDE CE, 
-- install the plugin on Android Studio, 
- try creating a feature on both of them.
