### PR TITLE
Update bloc cli dependencies

### DIFF
--- a/packages/rx_bloc_cli/bin/compile_win.bat
+++ b/packages/rx_bloc_cli/bin/compile_win.bat
@@ -19,7 +19,6 @@ dart run mason_cli:mason bundle -t dart mason_templates/bricks/rx_bloc_base ^
 & move /Y lib_permissions_bundle.dart lib\src\templates\ ^
 & move /Y lib_auth_bundle.dart lib\src\templates\ ^
 & move /Y lib_social_logins_bundle.dart lib\src\templates\ ^
-& move /Y lib_change_language.dart lib\src\templates\ ^
 & move /Y lib_dev_menu_bundle.dart lib\src\templates\ ^
 & move /Y lib_change_language_bundle.dart lib\src\templates\ ^
 & move /Y patrol_integration_tests_bundle.dart lib\src\templates\ ^

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_counter/__brick__/{{#enable_patrol}}integration_test{{/enable_patrol}}/main/pages/counter_page.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_counter/__brick__/{{#enable_patrol}}integration_test{{/enable_patrol}}/main/pages/counter_page.dart
@@ -13,11 +13,11 @@ class CounterPage extends BasePage {
   PatrolFinder get locBtnError => $(SmallButton);
 
   Future<void> tapBtnIncrement() async {
-    await $(K.counterIncrement).tap(andSettle: false);
+    await $(K.counterIncrement).tap(settlePolicy: SettlePolicy.noSettle);
   }
 
   Future<void> tapBtnDecrement() async {
-    await $(K.counterDecrement).tap(andSettle: false);
+    await $(K.counterDecrement).tap(settlePolicy: SettlePolicy.noSettle);
   }
 
   Future<void> tapBtnReload() async {

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_counter/__brick__/{{#enable_patrol}}integration_test{{/enable_patrol}}/tests/counter_test.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_counter/__brick__/{{#enable_patrol}}integration_test{{/enable_patrol}}/tests/counter_test.dart
@@ -20,6 +20,9 @@ void main() {
 
       //Log in
       await LoginPageSteps.loginAction($);
+      {{#enable_feature_otp}}
+      //TODO: Implement OTP page steps
+      {{/enable_feature_otp}}
       //Navigate to counter page
       await HomePageSteps.navigateToCounterPage($);
       //Increment counter 5 times

--- a/packages/rx_bloc_cli/mason_templates/bricks/lib_router/__brick__/lib/lib_router/router.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/lib_router/__brick__/lib/lib_router/router.dart
@@ -118,7 +118,7 @@ class AppRouter {
     }
 
     final pathInfo =
-        router.routeInformationParser.matcher.findMatch(state.location);
+        router.routeInformationParser.configuration.findMatch(state.location);
 
     final routeName = RouteModel.getRouteNameByFullPath(pathInfo.fullPath);
 

--- a/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/android/app/src/androidTest/java/{{domain_name}}/{{organization_name}}/{{project_name}}/MainActivityTest.java
+++ b/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/android/app/src/androidTest/java/{{domain_name}}/{{organization_name}}/{{project_name}}/MainActivityTest.java
@@ -1,13 +1,32 @@
 {{> licence.dart }}
 package {{domain_name}}.{{organization_name}}.{{project_name}}; 
 
-import org.junit.Rule;
+import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Test;
 import org.junit.runner.RunWith;
-import pl.leancode.patrol.PatrolTestRule;
-import pl.leancode.patrol.PatrolTestRunner;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import pl.leancode.patrol.PatrolJUnitRunner;
 
-@RunWith(PatrolTestRunner.class)
+@RunWith(Parameterized.class)
 public class MainActivityTest {
-    @Rule
-    public PatrolTestRule<MainActivity> rule = new PatrolTestRule<>(MainActivity.class);
+    @Parameters(name = "{0}")
+    public static Object[] testCases() {
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.setUp(MainActivity.class);
+        instrumentation.waitForPatrolAppService();
+        return instrumentation.listDartTests();
+    }
+
+    public MainActivityTest(String dartTestName) {
+        this.dartTestName = dartTestName;
+    }
+
+    private final String dartTestName;
+
+    @Test
+    public void runDartTest() {
+        PatrolJUnitRunner instrumentation = (PatrolJUnitRunner) InstrumentationRegistry.getInstrumentation();
+        instrumentation.runDartTest(dartTestName);
+    }
 }

--- a/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/integration_test/main/configuration/config_params.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/integration_test/main/configuration/config_params.dart
@@ -1,5 +1,7 @@
 {{> licence.dart }}
 
+import 'build_app.dart';
+
 class ConfigParams {
   const ConfigParams();
 
@@ -7,7 +9,7 @@ class ConfigParams {
   static const generalExistsTimeout = Duration(seconds: 10);
   static const generalVisibleTimeout = Duration(seconds: 10);
   static const generalSettleTimeout = Duration(seconds: 10);
-  static const generalAndSettle = true;
+  static const settlePolicy = SettlePolicy.settle;
 
   ///General NativeAutomatorConfig parameters
   static const generalConnectionTimeout = Duration(seconds: 60);

--- a/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/integration_test/main/configuration/config_params.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/integration_test/main/configuration/config_params.dart
@@ -9,7 +9,7 @@ class ConfigParams {
   static const generalExistsTimeout = Duration(seconds: 10);
   static const generalVisibleTimeout = Duration(seconds: 10);
   static const generalSettleTimeout = Duration(seconds: 10);
-  static const settlePolicy = SettlePolicy.settle;
+  static const settlePolicy = SettlePolicy.trySettle;
 
   ///General NativeAutomatorConfig parameters
   static const generalConnectionTimeout = Duration(seconds: 60);

--- a/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/integration_test/main/configuration/patrol_base_config.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/integration_test/main/configuration/patrol_base_config.dart
@@ -9,10 +9,11 @@ class PatrolBaseConfig {
   /// parameters section. More info -> at the class documentation.
   PatrolTesterConfig customPatrolTesterConfig() {
     PatrolTesterConfig patrolTesterConfig = const PatrolTesterConfig(
-        existsTimeout: ConfigParams.generalExistsTimeout,
-        visibleTimeout: ConfigParams.generalVisibleTimeout,
-        settleTimeout: ConfigParams.generalSettleTimeout,
-        andSettle: ConfigParams.generalAndSettle);
+      existsTimeout: ConfigParams.generalExistsTimeout,
+      visibleTimeout: ConfigParams.generalVisibleTimeout,
+      settleTimeout: ConfigParams.generalSettleTimeout,
+      settlePolicy: ConfigParams.settlePolicy,
+    );
     return patrolTesterConfig;
   }
 

--- a/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/ios/RunnerUITests/RunnerUITests.m
+++ b/packages/rx_bloc_cli/mason_templates/bricks/patrol_integration_tests/__brick__/ios/RunnerUITests/RunnerUITests.m
@@ -1,4 +1,5 @@
 @import XCTest;
 @import patrol;
+@import ObjectiveC.runtime;
 
 PATROL_INTEGRATION_TEST_IOS_RUNNER(RunnerUITests)

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/.gitignore
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/.gitignore
@@ -28,6 +28,7 @@ pubspec.lock
 .pub-cache/
 .pub/
 /build/
+integration_test/test_bundle.dart
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/app/build.gradle
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/app/build.gradle
@@ -74,7 +74,8 @@ android {
             versionNameSuffix ""{{#enable_social_logins}}
             resValue "string", "facebook_app_id", "insert_facebook_app_id"
             resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}} {{#enable_patrol}}
-            testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner" {{/enable_patrol}}
+            testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
+            testInstrumentationRunnerArguments clearPackageData: "true" {{/enable_patrol}}
         }
         staging {
             dimension "default"
@@ -82,7 +83,8 @@ android {
             versionNameSuffix "-stag"{{#enable_social_logins}}
             resValue "string", "facebook_app_id", "insert_facebook_app_id"
             resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}} {{#enable_patrol}}
-            testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner" {{/enable_patrol}}
+            testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
+            testInstrumentationRunnerArguments clearPackageData: "true" {{/enable_patrol}}
         }        
         development {
             dimension "default"
@@ -90,7 +92,8 @@ android {
             versionNameSuffix "-dev"{{#enable_social_logins}}
             resValue "string", "facebook_app_id", "insert_facebook_app_id"
             resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}} {{#enable_patrol}}
-            testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner" {{/enable_patrol}}
+            testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
+            testInstrumentationRunnerArguments clearPackageData: "true" {{/enable_patrol}}
         }
     }
 
@@ -104,6 +107,10 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+    {{#enable_patrol}}
+    testOptions {
+    execution "ANDROIDX_TEST_ORCHESTRATOR"
+    }{{/enable_patrol}}
 }
 
 flutter {
@@ -114,5 +121,5 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"{{#analytics}}
     implementation platform('com.google.firebase:firebase-bom:27.0.0')
     implementation 'com.google.firebase:firebase-analytics'{{/analytics}}{{#enable_patrol}}
-    testImplementation "junit:junit:4.13.2"{{/enable_patrol}}
+    androidTestUtil "androidx.test:orchestrator:1.4.2"{{/enable_patrol}}
 }

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/app/build.gradle
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/app/build.gradle
@@ -45,7 +45,9 @@ android {
         minSdkVersion 21
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionName flutterVersionName{{#enable_patrol}}
+        testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: "true" {{/enable_patrol}}
     }
 
     signingConfigs {
@@ -73,27 +75,21 @@ android {
             applicationIdSuffix ""
             versionNameSuffix ""{{#enable_social_logins}}
             resValue "string", "facebook_app_id", "insert_facebook_app_id"
-            resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}} {{#enable_patrol}}
-            testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
-            testInstrumentationRunnerArguments clearPackageData: "true" {{/enable_patrol}}
+            resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}}
         }
         staging {
             dimension "default"
             applicationIdSuffix ".stag"
             versionNameSuffix "-stag"{{#enable_social_logins}}
             resValue "string", "facebook_app_id", "insert_facebook_app_id"
-            resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}} {{#enable_patrol}}
-            testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
-            testInstrumentationRunnerArguments clearPackageData: "true" {{/enable_patrol}}
+            resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}}
         }        
         development {
             dimension "default"
             applicationIdSuffix ".dev"
             versionNameSuffix "-dev"{{#enable_social_logins}}
             resValue "string", "facebook_app_id", "insert_facebook_app_id"
-            resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}} {{#enable_patrol}}
-            testInstrumentationRunner "pl.leancode.patrol.PatrolJUnitRunner"
-            testInstrumentationRunnerArguments clearPackageData: "true" {{/enable_patrol}}
+            resValue "string", "facebook_client_token", "insert_client_token"{{/enable_social_logins}}
         }
     }
 

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/build.gradle
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.8.21'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"{{#analytics}}
         classpath 'com.google.gms:google-services:4.3.14'{{/analytics}}
     }

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/feature_home/views/home_page.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/feature_home/views/home_page.dart
@@ -25,6 +25,7 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final list = navItemsList(context);
     GoRouter router = GoRouter.of(context);
+    GoRouterState routerState = GoRouterState.of(context);
     return Scaffold(
       body: RxBlocListener<RouterBlocType, ErrorModel>(
         state: (bloc) => bloc.states.errors,
@@ -34,7 +35,7 @@ class HomePage extends StatelessWidget {
       bottomNavigationBar: BottomNavigationBar(
         key: K.bottomNavigationBar,
         type: BottomNavigationBarType.fixed,
-        currentIndex: _getCurrentIndex(list, router),
+        currentIndex: _getCurrentIndex(list, router, routerState),
         onTap: (index) =>
             context.read<RouterBlocType>().events.go(list[index].route),
         items: list
@@ -49,10 +50,11 @@ class HomePage extends StatelessWidget {
     );
   }
 
-  int _getCurrentIndex(List<NavMenuItem> list, GoRouter router) {
+  int _getCurrentIndex(
+      List<NavMenuItem> list, GoRouter router, GoRouterState goRouterState) {
     var index = list.indexWhere((item) {
-      final routePath =
-          router.routeInformationParser.matcher.findMatch(router.location);
+      final routePath = router.routeInformationParser.configuration
+          .findMatch(goRouterState.location);
       return routePath.fullPath.startsWith(item.routePath);
     });
     return index.isNegative ? 0 : index;

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/pubspec.yaml
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/pubspec.yaml
@@ -6,8 +6,7 @@ version: 1.0.0+1
 environment:
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
-  {{#enable_dev_menu}}
+dependencies: {{#enable_dev_menu}}
   alice: ^0.3.3 {{/enable_dev_menu}}
   collection: ^1.17.1
   cupertino_icons: ^1.0.5
@@ -18,8 +17,8 @@ dependencies:
   firebase_messaging: ^14.6.4{{/push_notifications}}
   flutter:
     sdk: flutter{{#enable_social_logins}}
-  flutter_facebook_auth: ^5.0.11{{/enable_social_logins}}
-  flutter_local_notifications: ^14.1.1
+  flutter_facebook_auth: ^6.0.0{{/enable_social_logins}}
+  flutter_local_notifications: ^15.1.0+1
   flutter_localizations:
     sdk: flutter
   flutter_rx_bloc: ^5.0.2
@@ -28,7 +27,7 @@ dependencies:
   go_router: ^9.0.0
   golden_toolkit: ^0.15.0{{#enable_social_logins}}
   google_sign_in: ^6.1.4{{/enable_social_logins}}
-  http: ^0.13.6 # This package is used for the local server (if not used, can be removed)
+  http: ^1.1.0 # This package is used for the local server (if not used, can be removed)
   jaguar_jwt: ^3.0.0 # This package is used for the local server (if not used, can be removed)
   json_annotation: ^4.8.1
   jwt_decoder: ^2.0.1{{#enable_feature_otp}}
@@ -56,7 +55,7 @@ dev_dependencies:
   go_router_builder: ^2.2.0
   json_serializable: ^6.7.0
   mockito: ^5.4.2 {{#enable_patrol}}
-  patrol: ^2.0.0 {{/enable_patrol}}
+  patrol: ^2.0.3 {{/enable_patrol}}
   r_flutter: 0.9.0
   retrofit_generator: ^7.0.7
   rx_bloc_generator: ^6.0.2

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/pubspec.yaml
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/pubspec.yaml
@@ -8,58 +8,58 @@ environment:
 
 dependencies:
   {{#enable_dev_menu}}
-  alice: ^0.3.2 {{/enable_dev_menu}}
-  collection: ^1.16.0
+  alice: ^0.3.3 {{/enable_dev_menu}}
+  collection: ^1.17.1
   cupertino_icons: ^1.0.5
   dio: ^5.2.1+1
   equatable: ^2.0.5{{#analytics}}
-  firebase_analytics: ^10.0.6{{/analytics}}{{#uses_firebase}}
-  firebase_core: ^2.3.0{{/uses_firebase}}{{#push_notifications}}
-  firebase_messaging: ^14.1.1{{/push_notifications}}
+  firebase_analytics: ^10.4.3{{/analytics}}{{#uses_firebase}}
+  firebase_core: ^2.14.0{{/uses_firebase}}{{#push_notifications}}
+  firebase_messaging: ^14.6.4{{/push_notifications}}
   flutter:
     sdk: flutter{{#enable_social_logins}}
-  flutter_facebook_auth: ^5.0.8{{/enable_social_logins}}
-  flutter_local_notifications: ^13.0.0
+  flutter_facebook_auth: ^5.0.11{{/enable_social_logins}}
+  flutter_local_notifications: ^14.1.1
   flutter_localizations:
     sdk: flutter
   flutter_rx_bloc: ^5.0.2
   flutter_secure_storage: ^8.0.0{{#enable_social_logins}}
-  flutter_svg: ^2.0.4{{/enable_social_logins}}
-  go_router: ^7.0.0
-  golden_toolkit: ^0.14.0{{#enable_social_logins}}
-  google_sign_in: ^6.0.2{{/enable_social_logins}}
-  http: ^0.13.5 # This package is used for the local server (if not used, can be removed)
+  flutter_svg: ^2.0.7{{/enable_social_logins}}
+  go_router: ^9.0.0
+  golden_toolkit: ^0.15.0{{#enable_social_logins}}
+  google_sign_in: ^6.1.4{{/enable_social_logins}}
+  http: ^0.13.6 # This package is used for the local server (if not used, can be removed)
   jaguar_jwt: ^3.0.0 # This package is used for the local server (if not used, can be removed)
-  json_annotation: ^4.7.0
+  json_annotation: ^4.8.1
   jwt_decoder: ^2.0.1{{#enable_feature_otp}}
   pinput: ^2.2.31{{/enable_feature_otp}}
-  provider: ^6.0.3
+  provider: ^6.0.5
   retrofit: ^4.0.1
   rx_bloc: ^4.0.0
   rx_bloc_list: ^3.2.1
-  rxdart: ^0.27.5
-  shared_preferences: ^2.0.15
-  shelf: ^1.4.0 # This package is used for the local server (if not used, can be removed)
-  shelf_router: ^1.1.3 # This package is used for the local server (if not used, can be removed)
-  shelf_static: ^1.1.1 # This package is used for the local server (if not used, can be removed){{#enable_social_logins}}
-  sign_in_with_apple: ^4.3.0{{/enable_social_logins}}
-  widget_toolkit: ^0.0.1-dev7{{#enable_feature_otp}}
+  rxdart: ^0.27.7
+  shared_preferences: ^2.1.2
+  shelf: ^1.4.1 # This package is used for the local server (if not used, can be removed)
+  shelf_router: ^1.1.4 # This package is used for the local server (if not used, can be removed)
+  shelf_static: ^1.1.2 # This package is used for the local server (if not used, can be removed){{#enable_social_logins}}
+  sign_in_with_apple: ^5.0.0{{/enable_social_logins}}
+  widget_toolkit: ^0.0.1-dev8{{#enable_feature_otp}}
   widget_toolkit_otp: ^0.0.1-dev3{{/enable_feature_otp}}
 
 dev_dependencies:
-  build_runner: ^2.3.0
+  build_runner: ^2.4.6
   # flutter_driver:
   #   sdk: flutter
   flutter_lints: any
   flutter_test:
     sdk: flutter
-  go_router_builder: ^2.0.0
-  json_serializable: ^6.5.1
-  mockito: ^5.3.2 {{#enable_patrol}}
-  patrol: ^1.1.2 {{/enable_patrol}}
+  go_router_builder: ^2.2.0
+  json_serializable: ^6.7.0
+  mockito: ^5.4.2 {{#enable_patrol}}
+  patrol: ^2.0.0 {{/enable_patrol}}
   r_flutter: 0.9.0
-  retrofit_generator: ^6.0.0+3
-  rx_bloc_generator: ^6.0.1
+  retrofit_generator: ^7.0.7
+  rx_bloc_generator: ^6.0.2
   rx_bloc_test: any
   test: any {{#enable_patrol}}
 

--- a/packages/rx_bloc_cli/pubspec.yaml
+++ b/packages/rx_bloc_cli/pubspec.yaml
@@ -9,16 +9,16 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  args: ^2.3.1
-  flutter_lints: ^2.0.1
+  args: ^2.4.2
+  flutter_lints: ^2.0.2
   mason: ^0.1.0-dev.49
-  path: ^1.8.2
+  path: ^1.8.3
 
 dev_dependencies:
   mason_cli: ^0.1.0-dev.50
 
 dependency_overrides:
-  pub_semver: ^2.1.4 # override this until 'mason' is updated to use 'pub_semver' 2.1.4 or newer
+  pub_semver: ^2.1.4 
 
 executables:
   rx_bloc_cli:

--- a/packages/rx_bloc_cli/pubspec.yaml
+++ b/packages/rx_bloc_cli/pubspec.yaml
@@ -11,11 +11,11 @@ environment:
 dependencies:
   args: ^2.4.2
   flutter_lints: ^2.0.2
-  mason: ^0.1.0-dev.49
+  mason: ^0.1.0-dev.50
   path: ^1.8.3
 
 dev_dependencies:
-  mason_cli: ^0.1.0-dev.50
+  mason_cli: ^0.1.0-dev.51
 
 dependency_overrides:
   pub_semver: ^2.1.4 


### PR DESCRIPTION
Close: #540 

### Description:
This pull request aims to update the dependencies in the rx_bloc_cli project as well as dependencies within the bricks to their latest versions.

Since counter integration test was made before implementing otp feature, the current counter integration test will fail if otp feature is enabled, and since otp feature is depending on [pinput package ](https://pub.dev/packages/pinput) currently there isn't a way of testing this feature.
Until this issue is solved I left a TODO to mark that there is a missing step in the counter test process
