### PR TITLE
Kotlin version updated

### DIFF
--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/build.gradle
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.22'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
Close: #538 
Kotlin version for rx_bloc_cli updated to `1.9.0` 