### PR TITLE
Fix generated project being created with parts of disabled bricks

### DIFF
--- a/packages/rx_bloc_cli/CHANGELOG.md
+++ b/packages/rx_bloc_cli/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.1.1]
+* Fix generated project not properly building when `pin_code` is disabled
+
 ## [3.1.0]
 * Added Fastlane as a CI/CD option under the flag `--cicd` (fastlane` (default), `none`)
 * Added PIN code as an option under the flag `--enable-pin-code`

--- a/packages/rx_bloc_cli/lib/src/rx_bloc_cli_constants.dart
+++ b/packages/rx_bloc_cli/lib/src/rx_bloc_cli_constants.dart
@@ -1,2 +1,2 @@
 /// Indicates the version of the package
-const rxBlocCliPackageVersion = '3.1.0';
+const rxBlocCliPackageVersion = '3.1.1';

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/base/app/{{project_name}}.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/base/app/{{project_name}}.dart
@@ -171,12 +171,12 @@ class __MyMaterialAppState extends State<_MyMaterialApp> {
           AnalyticsInterceptor(context.read()),{{/analytics}}
         );
   }
-{{#enable_dev_menu}}
+
   @override
   Widget build(BuildContext context) {
-    final materialApp = {{^enable_pin_code}} _buildMaterialApp(context);
-    {{/enable_pin_code}}{{#enable_pin_code}}
-      _buildMaterialAppWithPinCode(); {{/enable_pin_code}}
+    final materialApp = 
+    {{^enable_pin_code}} _buildMaterialApp(context);{{/enable_pin_code}}
+    {{#enable_pin_code}} _buildMaterialAppWithPinCode(); {{/enable_pin_code}}
 
       {{#enable_dev_menu}}
       if (EnvironmentConfig.enableDevMenu) {
@@ -189,7 +189,6 @@ class __MyMaterialAppState extends State<_MyMaterialApp> {
 
       return materialApp;
   }
-{{/enable_dev_menu}}
 {{#enable_pin_code}}
   Widget _buildMaterialAppWithPinCode() =>
       RxBlocBuilder<CreatePinBlocType, bool>(

--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/feature_profile/views/profile_page.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/feature_profile/views/profile_page.dart
@@ -163,7 +163,7 @@ class _ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
                   ),
                 ),
               ),
-            ),
+            ),{{#enable_pin_code}}
             RxBlocListener<CreatePinBlocType, bool>(
               state: (bloc) => bloc.states.isPinCreated,
               condition: (previous, current) =>
@@ -196,6 +196,7 @@ class _ProfilePageState extends State<ProfilePage> with WidgetsBindingObserver {
                  );
                },
              ),
+             {{/enable_pin_code}}
           ],
         ),
       );

--- a/packages/rx_bloc_cli/pubspec.yaml
+++ b/packages/rx_bloc_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rx_bloc_cli
 description: "rx_bloc_cli that enables quick project setup including: flavors, localization [intl], state management [rx_bloc], routing [go_router], design system, analytics [firebase], tests"
-version: 3.1.0
+version: 3.1.1
 repository: https://github.com/Prime-Holding/rx_bloc/tree/master/packages/rx_bloc_cli
 issue_tracker: https://github.com/Prime-Holding/rx_bloc/issues
 homepage: https://www.primeholding.com


### PR DESCRIPTION
This PR should fix issues with the generated project being created with some parts of disabled bricks.

The issue occurred when the project was generated with the interactive flag enabled, and using all the default values.

