### PR TITLE
Add github workflow for generating rx_bloc_cli projects

### DIFF
--- a/.github/workflows/test_rx_bloc_cli_project_generation.yaml
+++ b/.github/workflows/test_rx_bloc_cli_project_generation.yaml
@@ -1,0 +1,37 @@
+name: "Test rx_bloc_cli project generation"
+
+on:
+  push:
+    paths:
+      - "packages/rx_bloc_cli/**"
+  pull_request:
+    paths:
+      - "packages/rx_bloc_cli/**"
+
+jobs:
+  rx_bloc_cli_project_generation:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project_type:
+          [ "default", "all_disabled", "all_enabled", "without_showcase_features" ]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+         #flutter-version: # Specify your flutter version here or leave to use the latest one
+          channel: "stable"
+          cache: true
+          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+      - name: Setup environment
+        working-directory: "packages/rx_bloc_cli"
+        run: |
+          dart pub global activate mason_cli
+          dart pub get
+          sh bin/compile_bundles.sh
+      - name: Generate project
+        working-directory: "packages/rx_bloc_cli/bin"
+        run: |
+          echo "Generating project type: ${{matrix.project_type}}"
+          ./generate_test_project.sh ${{matrix.project_type}}

--- a/packages/rx_bloc_cli/bin/compile.sh
+++ b/packages/rx_bloc_cli/bin/compile.sh
@@ -1,26 +1,9 @@
 #!/usr/bin/env sh
+
 . $(dirname "$0")/compile_bundles.sh
 rm -rf example/test_app
 mkdir example/test_app
-dart run rx_bloc_cli create \
-  --project-name=testapp \
-  --organisation=com.primeholding \
-  --enable-analytics \
-  --enable-feature-counter \
-  --enable-feature-deeplinks \
-  --enable-feature-widget-toolkit \
-  --enable-login \
-  --enable-social-logins \
-  --enable-change-language \
-  --enable-dev-menu \
-  --enable-patrol \
-  --realtime-communication=sse \
-  --enable-otp \
-  --cicd=fastlane \
-  --enable-pin-code \
-  --enable-auth-matrix \
-  --no-interactive \
-  example/test_app
+$(dirname "$0")/generate_test_project.sh all_enabled
 
 # Copy the readme file one level up so that it is visible on the pub.dev page
 cp example/test_app/README.md example/

--- a/packages/rx_bloc_cli/bin/generate_test_project.sh
+++ b/packages/rx_bloc_cli/bin/generate_test_project.sh
@@ -64,17 +64,17 @@ fi
 if [ $1 == "without_showcase_features" ]; then
   # Generated project uses all features enabled except for showcase features
   generate --enable-analytics \
-  --enable-feature-deeplinks \
-  --enable-patrol \
-  --realtime-communication=sse \
-  --cicd=fastlane \
-  --no-enable-feature-counter \
-  --no-enable-dev-menu \
-  --no-enable-feature-widget-toolkit \
-  --no-enable-login \
-  --no-enable-social-logins \
-  --no-enable-change-language \
-  --no-enable-pin-code \
-  --no-enable-otp \
-  --no-enable-auth-matrix
-fi 
+    --enable-login \
+    --enable-social-logins \
+    --enable-change-language \
+    --enable-dev-menu \
+    --enable-patrol \
+    --realtime-communication=sse \
+    --enable-otp \
+    --cicd=fastlane \
+    --enable-pin-code \
+    --enable-auth-matrix \
+    --no-enable-feature-counter \
+    --no-enable-feature-widget-toolkit \
+    --no-enable-feature-deeplinks
+fi

--- a/packages/rx_bloc_cli/bin/generate_test_project.sh
+++ b/packages/rx_bloc_cli/bin/generate_test_project.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -e
+
+USAGE="Usage: generate_test_project.sh default|all_enabled|all_disabled|without_showcase_features"
+PROJECT_TYPES=("default" "all_enabled" "all_disabled" "without_showcase_features")
+
+if [ $# != 1 ]; then
+    echo $USAGE && exit 1
+fi
+
+function generate(){
+  dirname="test_app"
+  rm -rf example/$dirname
+  dart run $(dirname "$0")/rx_bloc_cli.dart create \
+   --no-interactive \
+   --project-name=testapp \
+   --organisation=com.primeholding \
+   $@ \
+   example/$dirname
+}
+
+if [ $1 == "default" ]; then
+  # Generated project should use default configuration
+  generate
+fi
+
+if [ $1 == "all_enabled" ]; then
+  # Generated project uses all features enabled
+  generate --enable-analytics \
+  --enable-feature-counter \
+  --enable-feature-deeplinks \
+  --enable-feature-widget-toolkit \
+  --enable-login \
+  --enable-social-logins \
+  --enable-change-language \
+  --enable-dev-menu \
+  --enable-patrol \
+  --realtime-communication=sse \
+  --enable-otp \
+  --cicd=fastlane \
+  --enable-pin-code \
+  --enable-auth-matrix
+fi 
+
+if [ $1 == "all_disabled" ]; then
+  # Generated project uses all features disabled
+  generate --no-enable-analytics \
+  --no-enable-feature-counter \
+  --no-enable-feature-deeplinks \
+  --no-enable-feature-widget-toolkit \
+  --no-enable-login \
+  --no-enable-social-logins \
+  --no-enable-change-language \
+  --no-enable-dev-menu \
+  --no-enable-patrol \
+  --realtime-communication=none \
+  --no-enable-otp \
+  --cicd=none \
+  --no-enable-pin-code \
+  --no-enable-auth-matrix
+fi 
+
+if [ $1 == "without_showcase_features" ]; then
+  # Generated project uses all features enabled except for showcase features
+  generate --enable-analytics \
+  --enable-feature-deeplinks \
+  --enable-patrol \
+  --realtime-communication=sse \
+  --cicd=fastlane \
+  --no-enable-feature-counter \
+  --no-enable-dev-menu \
+  --no-enable-feature-widget-toolkit \
+  --no-enable-login \
+  --no-enable-social-logins \
+  --no-enable-change-language \
+  --no-enable-pin-code \
+  --no-enable-otp \
+  --no-enable-auth-matrix
+fi 

--- a/packages/rx_bloc_cli/mason_templates/README.md
+++ b/packages/rx_bloc_cli/mason_templates/README.md
@@ -115,7 +115,7 @@ vars:
   # ...
 ```
 
-Update `compile.sh`, `compile_bundles.sh` and `compile_win.bat` with the newly included argument. 
+Update `generate_test_project.sh`, `compile_bundles.sh` and `compile_win.bat` with the newly included argument.
 
 The supported argument types are listed in the `ArgumentType` enum. 
 


### PR DESCRIPTION
Add github workflow for generating rx_bloc_cli projects with different flags

#### Overview

> Closes: #610 

This PR adds a github workflow which generates rx_bloc_cli test project with different configurations (default project generation, all flags enabled, all flags disabled, without showcase features). This allows for easier error checking when adding new or updating existing features/code.

#### Checklist

*Implementation*
- [x] Implementation matches ticket acceptance criteria and technical notes
- [x] Manually tested against Acceptance Criteria
~- [ ] UI checked in Light / Dark mode~

*Stability*
- [x] Checked if changes affect any features and verified affected features work as expected
~- [ ] Added unit tests for new code and verified existing tests work as expected~

*Code quality*
~- [] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`~
~- [ ] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations~
~- [ ] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes~