### PR TITLE
Add a fastlane task to prompt the user for envronment variables

### DIFF
--- a/packages/rx_bloc_cli/CHANGELOG.md
+++ b/packages/rx_bloc_cli/CHANGELOG.md
@@ -1,5 +1,8 @@
+## [3.x.x]
+* Update the build_custom fastlane task so that if the environment variables do not exist the user will be prompted to enter their values.
+
 ## [3.3.0]
-* Added Github as a CI/CD option under the flag `--cicd` (`fastlane` (default), `github`, none`)
+* Added Github as a CI/CD option under the flag `--cicd` (`fastlane` (default), `github`, `none`)
 * Added remote translation lookup for localizations
 * Updates to `analytics` feature - added crash reporting support and screen view logging
 * Update generated project dependencies 

--- a/packages/rx_bloc_cli/CHANGELOG.md
+++ b/packages/rx_bloc_cli/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [3.x.x]
-* Update the build_custom fastlane task so that if the environment variables do not exist the user will be prompted to enter their values.
+## [3.3.1]
+* Update the build_custom fastlane task so that if the required environment variables do not exist the user will be prompted to enter their values.
 
 ## [3.3.0]
 * Added Github as a CI/CD option under the flag `--cicd` (`fastlane` (default), `github`, `none`)

--- a/packages/rx_bloc_cli/CHANGELOG.md
+++ b/packages/rx_bloc_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [3.3.1]
-* Update the build_custom fastlane task so that if the required environment variables do not exist the user will be prompted to enter their values.
+* Update the build_custom fastlane task so that if the required environment variables do not exist the user will be prompted to enter their values
+* Convert the expected fastlane environment variables to uppercase
 
 ## [3.3.0]
 * Added Github as a CI/CD option under the flag `--cicd` (`fastlane` (default), `github`, `none`)

--- a/packages/rx_bloc_cli/lib/src/rx_bloc_cli_constants.dart
+++ b/packages/rx_bloc_cli/lib/src/rx_bloc_cli_constants.dart
@@ -1,2 +1,2 @@
 /// Indicates the version of the package
-const rxBlocCliPackageVersion = '3.3.0';
+const rxBlocCliPackageVersion = '3.3.1';

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
@@ -450,6 +450,14 @@ Expected environment variables:
     - mobile_distribution_encryption_password
     - mobile_distribution_repository_access_secret'
 lane :deploy do
+    if ENV['mobile_distribution_repository_access_secret'] == nil
+        setup_environment_variable(name: 'mobile_distribution_repository_access_secret')
+    end
+
+    if ENV['mobile_distribution_encryption_password'] == nil
+        setup_environment_variable(name: 'mobile_distribution_encryption_password')
+    end
+
     fetch_credentials()
 
     Dir.chdir('../devops/artifacts') do
@@ -472,6 +480,14 @@ Expected environment variables:
     - mobile_distribution_encryption_password
     - mobile_distribution_repository_access_secret'
 lane :deploy_debug_symbols do
+    if ENV['mobile_distribution_repository_access_secret'] == nil
+        setup_environment_variable(name: 'mobile_distribution_repository_access_secret')
+    end
+
+    if ENV['mobile_distribution_encryption_password'] == nil
+        setup_environment_variable(name: 'mobile_distribution_encryption_password')
+    end
+
     fetch_credentials()
 
     Dir.chdir('../devops/credentials/') do

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
@@ -66,13 +66,13 @@ end
 
 desc "Clones the credentials repository into devops/credentials.
 Expected environment variables:
-  - mobile_distribution_repository_access_secret"
+  - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET"
 private_lane :fetch_credentials do
     ensure_env_vars(
-        env_vars: ['mobile_distribution_repository_access_secret']
+        env_vars: ['MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET']
     )
 
-    token = ENV["mobile_distribution_repository_access_secret"]
+    token = ENV["MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET"]
 
     Dir.chdir("../devops") do
         unless Dir.exist?('credentials')
@@ -126,8 +126,8 @@ end
 
 desc "Start an automatic build
 Expected environment variables:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET
     - tag_build_trigger_reason_tag_name
 Expected input parameters:
     - platform: string (android, ios)
@@ -158,8 +158,8 @@ end
 
 desc "Start a custom build
 If the following environment variables are not set the task will prompt the user to enter them:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET
 Expected input parameters:
     - platform: string (android, ios)
     - build_name: string (1.2.0)
@@ -171,12 +171,12 @@ lane :build_custom do |options|
     environment = options[:environment]
     ensure_build_environment(environment: environment)
 
-    if ENV['mobile_distribution_repository_access_secret'] == nil
-        setup_environment_variable(name: 'mobile_distribution_repository_access_secret')
+    if ENV['MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET'] == nil
+        setup_environment_variable(name: 'MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET')
     end
 
-    if ENV['mobile_distribution_encryption_password'] == nil
-        setup_environment_variable(name: 'mobile_distribution_encryption_password')
+    if ENV['MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD'] == nil
+        setup_environment_variable(name: 'MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD')
     end
 
     set_platform(platform: options[:platform])
@@ -211,7 +211,7 @@ end
 platform :android do
     desc "Decode credentials for Android build and deployment
     Expected environment variables:
-      - mobile_distribution_encryption_password
+      - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
     Creates the following environment variables:
       - ANDROID_KEYSTORE_PATH
       - ANDROID_KEYSTORE_ALIAS
@@ -219,7 +219,7 @@ platform :android do
       - ANDROID_KEYSTORE_PASSWORD"
     private_lane :install_credentials do
         ensure_env_vars(
-            env_vars: ['mobile_distribution_encryption_password']
+            env_vars: ['MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD']
         )
 
         Dir.chdir("../devops/credentials") do
@@ -315,11 +315,11 @@ end
 platform :ios do
     desc 'Decode credentials for iOS build and deployment
     Expected environment variables:
-      - mobile_distribution_encryption_password'
+      - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD'
     private_lane :install_credentials do
         ensure_env_vars(
             env_vars: [
-                'mobile_distribution_encryption_password',
+                'MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD',
             ]
         )
 
@@ -447,15 +447,15 @@ end
 
 desc 'Deploy the build artifacts to the environment specified in deployment.yaml
 Expected environment variables:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret'
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET'
 lane :deploy do
-    if ENV['mobile_distribution_repository_access_secret'] == nil
-        setup_environment_variable(name: 'mobile_distribution_repository_access_secret')
+    if ENV['MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET'] == nil
+        setup_environment_variable(name: 'MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET')
     end
 
-    if ENV['mobile_distribution_encryption_password'] == nil
-        setup_environment_variable(name: 'mobile_distribution_encryption_password')
+    if ENV['MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD'] == nil
+        setup_environment_variable(name: 'MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD')
     end
 
     fetch_credentials()
@@ -477,15 +477,15 @@ end
 
 desc 'Deploy the debug symbols to firebase
 Expected environment variables:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret'
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET'
 lane :deploy_debug_symbols do
-    if ENV['mobile_distribution_repository_access_secret'] == nil
-        setup_environment_variable(name: 'mobile_distribution_repository_access_secret')
+    if ENV['MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET'] == nil
+        setup_environment_variable(name: 'MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET')
     end
 
-    if ENV['mobile_distribution_encryption_password'] == nil
-        setup_environment_variable(name: 'mobile_distribution_encryption_password')
+    if ENV['MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD'] == nil
+        setup_environment_variable(name: 'MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD')
     end
 
     fetch_credentials()

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
@@ -51,7 +51,18 @@ firebase_app_id_map = {
 
 keychain_path = Dir.getwd + '/devops/credentials/{{project_name.paramCase()}}-keychain.keychain'
 
-##################### Lanes #####################
+private_lane :setup_environment_variable do |options|
+    value = ''
+    loop do
+        value = prompt(
+            text: "Enter a value for #{options[:name]}: ",
+            secure_text: true
+        )
+        break if value.strip.length > 0
+    end
+
+    ENV[options[:name]] = value
+end
 
 desc "Clones the credentials repository into devops/credentials.
 Expected environment variables:
@@ -146,7 +157,7 @@ lane :build_flutter_app do |options|
 end
 
 desc "Start a custom build
-Expected environment variables:
+If the following environment variables are not set the task will prompt the user to enter them:
     - mobile_distribution_encryption_password
     - mobile_distribution_repository_access_secret
 Expected input parameters:
@@ -158,10 +169,17 @@ Example:
     fastlane build_custom platform:android build_name:1.2.0 build_number:121 environment:uat"
 lane :build_custom do |options|
     environment = options[:environment]
-
     ensure_build_environment(environment: environment)
-    set_platform(platform: options[:platform])
 
+    if ENV['mobile_distribution_repository_access_secret'] == nil
+        setup_environment_variable(name: 'mobile_distribution_repository_access_secret')
+    end
+
+    if ENV['mobile_distribution_encryption_password'] == nil
+        setup_environment_variable(name: 'mobile_distribution_encryption_password')
+    end
+
+    set_platform(platform: options[:platform])
     generate_code()
     fetch_credentials()
     install_credentials()

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/README.md
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/README.md
@@ -21,8 +21,8 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Start an automatic build
 Expected environment variables:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET
     - tag_build_trigger_reason_tag_name
 Expected input parameters:
     - platform: string (android, ios)
@@ -37,8 +37,8 @@ Example:
 
 Start a custom build
 If the following environment variables are not set the task will prompt the user to enter them:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET
 Expected input parameters:
     - platform: string (android, ios)
     - build_name: string (1.2.0)
@@ -55,8 +55,8 @@ Example:
 
 Deploy the build artifacts to the environment specified in deployment.yaml
 Expected environment variables:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET
 
 ### deploy_debug_symbols
 
@@ -66,8 +66,8 @@ Expected environment variables:
 
 Deploy the debug symbols to firebase
 Expected environment variables:
-    - mobile_distribution_encryption_password
-    - mobile_distribution_repository_access_secret
+    - MOBILE_DISTRIBUTION_ENCRYPTION_PASSWORD
+    - MOBILE_DISTRIBUTION_REPOSITORY_ACCESS_SECRET
 
 ----
 

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/README.md
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/README.md
@@ -36,7 +36,7 @@ Example:
 ```
 
 Start a custom build
-Expected environment variables:
+If the following environment variables are not set the task will prompt the user to enter them:
     - mobile_distribution_encryption_password
     - mobile_distribution_repository_access_secret
 Expected input parameters:

--- a/packages/rx_bloc_cli/pubspec.yaml
+++ b/packages/rx_bloc_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rx_bloc_cli
 description: "rx_bloc_cli that enables quick project setup including: flavors, localization [intl], state management [rx_bloc], routing [go_router], design system, analytics [firebase], tests"
-version: 3.3.0
+version: 3.3.1
 repository: https://github.com/Prime-Holding/rx_bloc/tree/master/packages/rx_bloc_cli
 issue_tracker: https://github.com/Prime-Holding/rx_bloc/issues
 homepage: https://www.primeholding.com


### PR DESCRIPTION
#### Overview

This PR updates the build_custom fastlane task so that if the environment variables do not exist the user will be prompted to enter their values.

#### Checklist

*Implementation*
- [x] Manually tested against Acceptance Criteria

*Stability*
- [x] Checked if changes affect any features and verified affected features work as expected

*Code quality*
- [x] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`