### PR TITLE
Remove RxTextFormFieldBuilder suffix icon padding

### DIFF
--- a/packages/flutter_rx_bloc/CHANGELOG.md
+++ b/packages/flutter_rx_bloc/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [6.1.1]
+* Fixes an issue where RxTextFormFieldBuilder suffixIcon was not centered on text fields with smaller height
+
 ## [6.1.0]
 * Introduce `RxBlocMultiBuilder2` and `RxBlocMultiBuilder3`
 

--- a/packages/flutter_rx_bloc/lib/src/rx_text_form_field_builder.dart
+++ b/packages/flutter_rx_bloc/lib/src/rx_text_form_field_builder.dart
@@ -283,12 +283,9 @@ class RxTextFormFieldBuilderState<B extends RxBlocTypeBase>
                     _isTextObscured = !_isTextObscured;
                   });
                 },
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: _isTextObscured
-                      ? widget.decorationData.iconVisibility
-                      : widget.decorationData.iconVisibilityOff,
-                ),
+                child: _isTextObscured
+                    ? widget.decorationData.iconVisibility
+                    : widget.decorationData.iconVisibilityOff,
               )
             : null,
         errorText: showError ? error : null,

--- a/packages/flutter_rx_bloc/pubspec.yaml
+++ b/packages/flutter_rx_bloc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rx_bloc
 description: Set of Flutter Widgets that help implementing the BLoC design pattern. Built to be used with the rx_bloc package.
-version: 6.1.0
+version: 6.1.1
 repository: https://github.com/Prime-Holding/rx_bloc/tree/master/packages/flutter_rx_bloc
 issue_tracker: https://github.com/Prime-Holding/rx_bloc/issues
 homepage: https://primeholding.com
@@ -11,18 +11,18 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  provider: ^6.0.5
+  provider: ^6.1.1
   rx_bloc: ^5.0.0
   rxdart: ^0.27.7
 
 dev_dependencies:
-  build_runner: ^2.4.5
+  build_runner: ^2.4.8
   clean_coverage: ^0.0.3
   flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.4.2
-  test: ^1.24.1
+  mockito: ^5.4.4
+  test: ^1.24.9
 
 flutter:
   # assets:

--- a/packages/flutter_rx_bloc/pubspec.yaml
+++ b/packages/flutter_rx_bloc/pubspec.yaml
@@ -11,18 +11,18 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  provider: ^6.1.1
+  provider: ^6.0.5
   rx_bloc: ^5.0.0
   rxdart: ^0.27.7
 
 dev_dependencies:
-  build_runner: ^2.4.8
+  build_runner: ^2.4.5
   clean_coverage: ^0.0.3
   flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.4.4
-  test: ^1.24.9
+  mockito: ^5.4.2
+  test: ^1.24.1
 
 flutter:
   # assets:


### PR DESCRIPTION
#### Overview

This PR should fix the padding of the suffix icon of RxTextFormFieldBuilder.
The bug occurs when the RxTextFormFieldBuilder is used with the TextField or TextFormField that has a specified height of under 50 pixels. 

Screenshots of before and after are included ⬇️ 

![Screenshot_1707303329](https://github.com/Prime-Holding/rx_bloc/assets/122014682/99c3b735-47b3-4244-80db-4a39ed4794d7)
![Screenshot_1707303338](https://github.com/Prime-Holding/rx_bloc/assets/122014682/8113abba-1cc1-4962-90fe-ecfde6ca658f)

#### Checklist

*Implementation*
- [ ] ~~Implementation matches ticket acceptance criteria and technical notes~~
- [x] Manually tested against Acceptance Criteria
- [ ] ~~UI checked in Light / Dark mode~~

*Stability*
- [ ] ~~Checked if changes affect any features and verified affected features work as expected~~
- [ ] ~~Added unit tests for new code and verified existing tests work as expected~~

*Code quality*
- [x] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [x] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [x] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes