### PR TITLE
Update dependencies and bump analyzer constraints to ^6.5.0

### DIFF
--- a/packages/rx_bloc_generator/CHANGELOG.md
+++ b/packages/rx_bloc_generator/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [7.2.2]
-* Update dependencies and bump analyzer constraints to ^6.5.0
+* Fix compiling issue caused by the analyzer version `6.5.0`
 
 ## [7.2.1]
 * Support Flutter `3.22`

--- a/packages/rx_bloc_generator/CHANGELOG.md
+++ b/packages/rx_bloc_generator/CHANGELOG.md
@@ -1,14 +1,17 @@
-## [7.2.1] - May 31, 2024
+## [7.2.2]
+* Update dependencies and bump analyzer constraints to ^6.5.0
+
+## [7.2.1]
 * Support Flutter `3.22`
 
-## [7.2.0] - February 20, 2024
+## [7.2.0]
 * Support Flutter `3.19`
 
-## [7.1.0] - December 1, 2023
+## [7.1.0]
 * Support Flutter `3.16`
 * Update dependencies and bump analyzer constraints to `>=6.0.0 <7.0.0` 
 
-## [7.0.0] - July 12, 2023
+## [7.0.0]
 * Dart `3.0` Required
 * _[BREAKING CHANGE]_ Version >=7.0.0 introduces a change by generating named record instead of event arguments class.
 ```dart
@@ -22,45 +25,45 @@ void subtract(int a, int b);
   ```
 * Update dependencies
 
-## [6.0.2] - April 7, 2023
+## [6.0.2]
 * Update dependencies
 
-## [6.0.1] - January 27, 2023
+## [6.0.1]
 * Drop upper version requirement for the analyzer dependency
 * Update `rx_bloc` to use version `4.0.0`
 
-## [6.0.0] - July 28, 2022
+## [6.0.0]
 * Update dependencies
 * _[BREAKING CHANGE]_ Update analyzer to `">=3.0.0 <=5.0.0"`
 * Add support for generic blocs (Thanks [jld3103](https://github.com/jld3103) for the contribution)
 
-## [5.1.1] - December 24, 2021
+## [5.1.1]
 * Update dependencies 
 
-## [5.1.0] - September 24, 2021
+## [5.1.0] 
 * Support Flutter `2.5`
 * Update `rxdart` to use version `0.27.2`
 
-## [5.0.1] - September 22, 2021
+## [5.0.1] 
 * Allow generating behaviour subject events without a seed
 
-## [5.0.0] - May 21, 2021
+## [5.0.0] 
 * Support Flutter `2.2`
 * Update `rxdart` to use version `0.27.0`
 
-## [4.0.0] - April 28, 2021
+## [4.0.0] 
 * Upgraded (`null-safety`) dependencies
 
-## [3.0.2] - April 05, 2021
+## [3.0.2] 
 * Added type to the BehaviorSubject with seed value, Example: `final _$reloadEvent = BehaviorSubject<bool>.seeded(null);`
 
-## [3.0.1] - March 22, 2021
+## [3.0.1] 
 * Dependencies clean-up
 
-## [3.0.0] - March 10, 2021
+## [3.0.0]
 * Migrated to Flutter `2.0` and Dart `2.12` (null-safety).
 
-## [2.0.0] - February 12, 2021
+## [2.0.0] 
 * Support events with optional parameter and enum default value
 * Support events with named parameter and a default value
 * Support events with positional and optional parameters at the same time
@@ -80,45 +83,45 @@ void subtract(int a, int b);
  * Stability improvements
  * Improved error handling
 
-## [1.0.1] - December 08, 2020
+## [1.0.1] 
 * Stability improvements
 
-## [1.0.0] - December 02, 2020
+## [1.0.0] 
 * Consolidated rx_bloc ecosystem [in one repository](https://github.com/Prime-Holding/rx_bloc)
 * Removed flutter dependency
 * Applied strict static code analysis
 * Fixes and improvements
 
-## [0.2.1] - May 5, 2020
+## [0.2.1] 
 * Updated package dependencies
 * Reorganized package
 
-## [0.2.0] - May 5, 2020
+## [0.2.0]
 
 * Improved error handling and displaying:
   Error messages are logged in the console with an [ERROR] tag and a red color for easier noticing
 * Events (and seeds using the @RxBlocEvent annotation) support multiple parameters
 
-## [0.1.3] - April 7, 2020
+## [0.1.3] 
 
 * Updated package dependencies
 
-## [0.1.2] - March 19, 2020
+## [0.1.2]
 
 * Fixed generation of `part of` 
 * Updated `rx_bloc` package to `0.2.0`
 
-## [0.1.1] - March 16, 2020
+## [0.1.1]
 
 * Fixed conflicting outputs with other builders
 
-## [0.1.0] - March 14, 2020
+## [0.1.0] 
 
 * Implemented @RxBlocEvent annotation
 * Generated event subjects and mappers are now private to the BloC
 * Updated README file
 * Updated rx_bloc dependency
 
-## [0.0.1] - Jan 16, 2020
+## [0.0.1] 
 
 * Initial release

--- a/packages/rx_bloc_generator/lib/src/builders/state_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_field.dart
@@ -18,7 +18,7 @@ class _StateField implements _BuilderContract {
             ]
           ])
           ..type = refer(
-            'late final ${field.type.getDisplayString()}',
+            'late final ${field.type.getDisplayString(withNullability: true)}',
           )
           ..assignment = refer(field.stateMethodName).newInstance([]).code
           ..name = field.stateFieldName,

--- a/packages/rx_bloc_generator/lib/src/builders/state_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_field.dart
@@ -18,6 +18,7 @@ class _StateField implements _BuilderContract {
             ]
           ])
           ..type = refer(
+            //ignore: deprecated_member_use
             'late final ${field.type.getDisplayString(withNullability: true)}',
           )
           ..assignment = refer(field.stateMethodName).newInstance([]).code

--- a/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
@@ -12,7 +12,7 @@ class _StateGetterMethod implements _BuilderContract {
           ..docs.addAll(['']) // A new line
           ..type = MethodType.getter
           ..annotations.add(refer('override'))
-          ..returns = refer(field.type.getDisplayString())
+          ..returns = refer(field.type.getDisplayString(withNullability: true))
           ..name = field.name
           ..lambda = true
           ..body = refer(field.stateFieldName).code,

--- a/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
@@ -12,6 +12,7 @@ class _StateGetterMethod implements _BuilderContract {
           ..docs.addAll(['']) // A new line
           ..type = MethodType.getter
           ..annotations.add(refer('override'))
+          //ignore: deprecated_member_use
           ..returns = refer(field.type.getDisplayString(withNullability: true))
           ..name = field.name
           ..lambda = true

--- a/packages/rx_bloc_generator/lib/src/builders/state_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_method.dart
@@ -11,7 +11,7 @@ class _StateMethod implements _BuilderContract {
         (b) => b
           ..docs.addAll(['']) // A new line
           ..returns = refer(
-            field.type.getDisplayString(),
+            field.type.getDisplayString(withNullability: true),
           )
           ..name = field.stateMethodName,
       );

--- a/packages/rx_bloc_generator/lib/src/builders/state_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_method.dart
@@ -11,6 +11,7 @@ class _StateMethod implements _BuilderContract {
         (b) => b
           ..docs.addAll(['']) // A new line
           ..returns = refer(
+            //ignore: deprecated_member_use
             field.type.getDisplayString(withNullability: true),
           )
           ..name = field.stateMethodName,

--- a/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
+++ b/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
@@ -97,6 +97,7 @@ extension _EventMethodElement on MethodElement {
   ElementAnnotation? get _rxBlocEventAnnotation => _eventAnnotation
               ?.computeConstantValue()
               ?.type
+              //ignore: deprecated_member_use
               ?.getDisplayString(withNullability: true) ==
           (RxBlocEvent).toString()
       ? _eventAnnotation
@@ -117,6 +118,7 @@ extension _EventMethodElement on MethodElement {
     }
     return parameters.isNotEmpty
         // The only parameter's type
+        //ignore: deprecated_member_use
         ? parameters.first.type.getDisplayString(withNullability: true)
         // Default type
         : 'void';
@@ -195,5 +197,6 @@ extension _ListParameterElementClone on Iterable<ParameterElement> {
 }
 
 extension _ParameterElementToString on ParameterElement {
+  //ignore: deprecated_member_use
   String getTypeDisplayName() => type.getDisplayString(withNullability: true);
 }

--- a/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
+++ b/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
@@ -94,11 +94,13 @@ extension _EventMethodElement on MethodElement {
       _rxBlocEventAnnotation?.computeConstantValue();
 
   /// Provides the [RxBlocEvent] annotation as [ElementAnnotation] if exists
-  ElementAnnotation? get _rxBlocEventAnnotation =>
-      _eventAnnotation?.computeConstantValue()?.type?.getDisplayString() ==
-              (RxBlocEvent).toString()
-          ? _eventAnnotation
-          : null;
+  ElementAnnotation? get _rxBlocEventAnnotation => _eventAnnotation
+              ?.computeConstantValue()
+              ?.type
+              ?.getDisplayString(withNullability: true) ==
+          (RxBlocEvent).toString()
+      ? _eventAnnotation
+      : null;
 
   /// Is the event stream type a BehaviorSubject
   bool get isBehavior =>
@@ -115,7 +117,7 @@ extension _EventMethodElement on MethodElement {
     }
     return parameters.isNotEmpty
         // The only parameter's type
-        ? parameters.first.type.getDisplayString()
+        ? parameters.first.type.getDisplayString(withNullability: true)
         // Default type
         : 'void';
   }
@@ -193,5 +195,5 @@ extension _ListParameterElementClone on Iterable<ParameterElement> {
 }
 
 extension _ParameterElementToString on ParameterElement {
-  String getTypeDisplayName() => type.getDisplayString();
+  String getTypeDisplayName() => type.getDisplayString(withNullability: true);
 }

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dependencies:
-  analyzer: ^6.5.0
+  analyzer: ">=6.0.0 <7.0.0"
   build: ^2.4.0
   code_builder: ^4.10.0
   collection: ^1.17.1

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.0.0 <6.5.0"
+  analyzer: ^6.0.0
   build: ^2.4.0
   code_builder: ^4.10.0
   collection: ^1.17.1
@@ -22,6 +22,6 @@ dev_dependencies:
   build_runner: ^2.4.8
   clean_coverage: ^0.0.3
   coverage: ^1.7.2
-  flutter_lints: ^3.0.1
+  flutter_lints: ^4.0.0
   source_gen_test: ^1.0.5
   test: ^1.25.2

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.0.0 <7.0.0"
+  analyzer: ^6.5.0
   build: ^2.4.0
   code_builder: ^4.10.0
   collection: ^1.17.1

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rx_bloc_generator
 description: Code generator for rx_bloc that makes your BloC zero-boilerplate.
-version: 7.2.1
+version: 7.2.2
 repository: https://github.com/Prime-Holding/rx_bloc/tree/master/packages/rx_bloc_generator
 issue_tracker: https://github.com/Prime-Holding/rx_bloc/issues
 homepage: https://www.primeholding.com/

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.0.0 <7.0.0"
+  analyzer: ">=6.0.0 <6.5.0"
   build: ^2.4.0
   code_builder: ^4.10.0
   collection: ^1.17.1


### PR DESCRIPTION
#### Overview

Fix compiling issue caused by the analyzer version 6.5.0

<img width="742" alt="image" src="https://github.com/Prime-Holding/rx_bloc/assets/32831935/9c923db2-9d03-468b-b83e-bee140a36559">

#### Checklist

*Implementation*
- [x] Implementation matches ticket acceptance criteria and technical notes
- [ ] Manually tested against Acceptance Criteria
- [x] UI checked in Light / Dark mode

*Stability*
- [ ] Checked if changes affect any features and verified affected features work as expected
- [x] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [x] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [x] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [x] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes