### PR TITLE
Feature/todoapp implementation hot fixes

### DIFF
--- a/examples/todoapp/lib/base/common_ui_components/todo_widget.dart
+++ b/examples/todoapp/lib/base/common_ui_components/todo_widget.dart
@@ -8,10 +8,12 @@ class TodoWidget extends StatelessWidget {
     super.key,
     required this.todo,
     this.onChanged,
+    this.descriptionMaxLines,
   });
 
   final TodoModel todo;
   final Function(TodoModel todo, bool? isChecked)? onChanged;
+  final int? descriptionMaxLines;
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +32,7 @@ class TodoWidget extends StatelessWidget {
               style: context.designSystem.typography.h2Med16,
               todo.title,
             ),
-            if (todo.description.isNotEmpty) Text(todo.description),
+            if (todo.description.isNotEmpty) Text(todo.description, maxLines: descriptionMaxLines,),
           ],
         ),
       ],

--- a/examples/todoapp/lib/base/data_sources/local/todo_list_local_data_source.dart
+++ b/examples/todoapp/lib/base/data_sources/local/todo_list_local_data_source.dart
@@ -20,12 +20,12 @@ import 'shared_preferences_instance.dart';
 class TodoListDataSource {
   TodoListDataSource(this._sharedPreferences);
 
-  static const _todoList = 'todoList';
+  static const _todoListPreferencesKey = 'todoList';
 
   final SharedPreferencesInstance _sharedPreferences;
 
   Future<List<TodoModel>> fetchAllTodos() async {
-    var listJson = await _sharedPreferences.getString(_todoList);
+    var listJson = await _sharedPreferences.getString(_todoListPreferencesKey);
     List<TodoModel> result = List<TodoModel>.empty(growable: true);
 
     if (listJson != null && listJson.isNotEmpty) {
@@ -38,7 +38,7 @@ class TodoListDataSource {
   }
 
   Future<TodoModel> addOrUpdateTodo(TodoModel todo) async {
-    var listJson = await _sharedPreferences.getString(_todoList);
+    var listJson = await _sharedPreferences.getString(_todoListPreferencesKey);
     List<TodoModel> todos = [];
 
     if (listJson != null && listJson.isNotEmpty) {
@@ -59,13 +59,13 @@ class TodoListDataSource {
       todos.insert(0, todo);
     }
 
-    await _sharedPreferences.setString(_todoList, jsonEncode(todos));
+    await _sharedPreferences.setString(_todoListPreferencesKey, jsonEncode(todos));
 
     return todo;
   }
 
   Future<TodoModel> updateCompletedById(String id, bool completed) async {
-    var listJson = await _sharedPreferences.getString(_todoList);
+    var listJson = await _sharedPreferences.getString(_todoListPreferencesKey);
 
     if (listJson != null && listJson.isNotEmpty) {
       List<dynamic> parsedListJson = jsonDecode(listJson);
@@ -76,7 +76,7 @@ class TodoListDataSource {
       if (index >= 0) {
         todos[index] = todos[index].copyWith(completed: completed);
 
-        await _sharedPreferences.setString(_todoList, jsonEncode(todos));
+        await _sharedPreferences.setString(_todoListPreferencesKey, jsonEncode(todos));
 
         return todos[index];
       }
@@ -88,7 +88,7 @@ class TodoListDataSource {
   }
 
   Future<List<TodoModel>> updateCompletedForAll(bool completed) async {
-    var listJson = await _sharedPreferences.getString(_todoList);
+    var listJson = await _sharedPreferences.getString(_todoListPreferencesKey);
 
     if (listJson?.isNotEmpty ?? true) {
       List<dynamic> parsedListJson = jsonDecode(listJson!);
@@ -98,7 +98,7 @@ class TodoListDataSource {
       todos.forEachIndexed(
           (index, todo) => todos[index] = todo.copyWith(completed: completed));
 
-      await _sharedPreferences.setString(_todoList, jsonEncode(todos));
+      await _sharedPreferences.setString(_todoListPreferencesKey, jsonEncode(todos));
 
       return todos;
     }
@@ -107,7 +107,7 @@ class TodoListDataSource {
   }
 
   Future<List<TodoModel>> deleteCompleted() async {
-    var listJson = await _sharedPreferences.getString(_todoList);
+    var listJson = await _sharedPreferences.getString(_todoListPreferencesKey);
 
     if (listJson?.isNotEmpty ?? true) {
       List<dynamic> parsedListJson = jsonDecode(listJson!);
@@ -117,9 +117,9 @@ class TodoListDataSource {
       todos.removeWhere((element) => element.completed == true);
 
       if (todos.isEmpty) {
-        await _sharedPreferences.remove(_todoList);
+        await _sharedPreferences.remove(_todoListPreferencesKey);
       } else {
-        await _sharedPreferences.setString(_todoList, jsonEncode(todos));
+        await _sharedPreferences.setString(_todoListPreferencesKey, jsonEncode(todos));
       }
 
       return todos;
@@ -129,7 +129,7 @@ class TodoListDataSource {
   }
 
   Future<void> deleteById(String id) async {
-    var listJson = await _sharedPreferences.getString(_todoList);
+    var listJson = await _sharedPreferences.getString(_todoListPreferencesKey);
 
     if (listJson?.isNotEmpty ?? true) {
       List<dynamic> parsedListJson = jsonDecode(listJson!);
@@ -143,12 +143,12 @@ class TodoListDataSource {
         }
       }
 
-      unawaited(_sharedPreferences.setString(_todoList, jsonEncode(todos)));
+      unawaited(_sharedPreferences.setString(_todoListPreferencesKey, jsonEncode(todos)));
     }
   }
 
   Future<TodoModel> fetchTodoById(String id) async {
-    var listJson = await _sharedPreferences.getString(_todoList);
+    var listJson = await _sharedPreferences.getString(_todoListPreferencesKey);
     TodoModel? result;
 
     if (listJson?.isNotEmpty ?? true) {

--- a/examples/todoapp/lib/base/di/todoapp_with_dependencies.dart
+++ b/examples/todoapp/lib/base/di/todoapp_with_dependencies.dart
@@ -156,7 +156,6 @@ class TodoappWithDependencies extends StatelessWidget {
           create: (context) => TodoListRepository(
             context.read(),
             context.read(),
-            //context.read(),
           ),
         ),
       ];

--- a/examples/todoapp/lib/base/extensions/subject_extensions.dart
+++ b/examples/todoapp/lib/base/extensions/subject_extensions.dart
@@ -1,0 +1,10 @@
+import 'package:rxdart/rxdart.dart';
+
+extension SubjectExtensions on Subject {
+  /// check if the subject is closed before closing it
+  void closeSafely() {
+    if (!isClosed) {
+      close();
+    }
+  }
+}

--- a/examples/todoapp/lib/feature_todo_details/blocs/todo_details_bloc.dart
+++ b/examples/todoapp/lib/feature_todo_details/blocs/todo_details_bloc.dart
@@ -16,7 +16,7 @@ part 'todo_details_bloc.rxb.g.dart';
 /// A contract class containing all events of the TodoDetailsBloC.
 abstract class TodoDetailsBlocEvents {
   /// Notifies the [RouterBloc] to navigate to the [TodoUpdateRoute]
-  void manage();
+  void updateTodo();
 
   /// Fetch the todo
   void fetchTodo();
@@ -73,7 +73,7 @@ class TodoDetailsBloc extends $TodoDetailsBloc {
       ]).publish();
 
   @override
-  ConnectableStream<void> _mapToOnRoutingState() => _$manageEvent
+  ConnectableStream<void> _mapToOnRoutingState() => _$updateTodoEvent
       .withLatestFrom(todo, (_, todo) => todo)
       .doOnData(
         (todo) => _routerBloc.events.go(TodoUpdateRoute(todo.id!), extra: todo),

--- a/examples/todoapp/lib/feature_todo_details/blocs/todo_details_bloc.dart
+++ b/examples/todoapp/lib/feature_todo_details/blocs/todo_details_bloc.dart
@@ -31,7 +31,7 @@ abstract class TodoDetailsBlocStates {
   Stream<ErrorModel> get errors;
 
   /// The todo state of the todo details page
-  ConnectableStream<TodoModel> get todo;
+  ConnectableStream<Result<TodoModel>> get todo;
 
   /// The state of the routing event
   ConnectableStream<void> get onRouting;
@@ -57,7 +57,7 @@ class TodoDetailsBloc extends $TodoDetailsBloc {
   final RouterBlocType _routerBloc;
 
   @override
-  ConnectableStream<TodoModel> _mapToTodoState() => _$fetchTodoEvent
+  ConnectableStream<Result<TodoModel>> _mapToTodoState() => _$fetchTodoEvent
           .startWith(null)
           .switchMap(
             (_) => _todoListService
@@ -65,16 +65,17 @@ class TodoDetailsBloc extends $TodoDetailsBloc {
                 .asResultStream(),
           )
           .setResultStateHandler(this)
-          .whereSuccess()
           .mergeWith([
         _coordinatorBloc.states.onTodoAddedOrUpdated
             .whereSuccess()
             .where((updatedTodo) => _todoId == updatedTodo.id)
+            .mapToResult()
       ]).publish();
 
   @override
   ConnectableStream<void> _mapToOnRoutingState() => _$updateTodoEvent
       .withLatestFrom(todo, (_, todo) => todo)
+      .whereSuccess()
       .doOnData(
         (todo) => _routerBloc.events.go(TodoUpdateRoute(todo.id!), extra: todo),
       )

--- a/examples/todoapp/lib/feature_todo_details/views/todo_details_page.dart
+++ b/examples/todoapp/lib/feature_todo_details/views/todo_details_page.dart
@@ -5,9 +5,10 @@ import 'package:widget_toolkit/ui_components.dart';
 
 import '../../app_extensions.dart';
 import '../../base/common_ui_components/app_bar_title.dart';
-import '../../base/common_ui_components/app_error_modal_widget.dart';
+import '../../base/common_ui_components/app_error_widget.dart';
 import '../../base/common_ui_components/todo_widget.dart';
 import '../../base/extensions/async_snapshot_extensions.dart';
+import '../../base/models/errors/error_model.dart';
 import '../../base/models/todo_model.dart';
 import '../../lib_todo_actions/blocs/todo_actions_bloc.dart';
 import '../blocs/todo_details_bloc.dart';
@@ -51,31 +52,44 @@ class TodoDetailsPage extends StatelessWidget {
         ),
         body: Column(
           children: [
-            RxBlocBuilder<TodoDetailsBlocType, TodoModel>(
-              state: (bloc) => bloc.states.todo,
-              builder: (context, todoSnapshot, bloc) {
-                if (todoSnapshot.hasData) {
-                  return TodoWidget(
-                    todo: todoSnapshot.data!,
-                    onChanged: (todo, isChecked) {
-                      final todoId = todo.id;
+            RxBlocMultiBuilder2<TodoDetailsBlocType, TodoModel, ErrorModel>(
+                state1: (bloc) => bloc.states.todo,
+                state2: (bloc) => bloc.states.errors,
+                builder: (context, todoSnapshot, errorSnapshot, bloc) {
+                  if (errorSnapshot.hasData) {
+                    return Column(
+                      children: [
+                        SizedBox(
+                          height: context.designSystem.spacing.l,
+                        ),
+                        Center(
+                          child: AppErrorWidget(
+                            error: errorSnapshot.data!,
+                            onTabRetry: () => bloc.events.fetchTodo(),
+                          ),
+                        ),
+                      ],
+                    );
+                  }
 
-                      if (todoId != null) {
-                        context
-                            .read<TodoActionsBlocType>()
-                            .events
-                            .updateCompletedById(todo.id!, isChecked!);
-                      }
-                    },
-                  );
-                }
+                  if (todoSnapshot.hasData) {
+                    return TodoWidget(
+                      todo: todoSnapshot.data!,
+                      onChanged: (todo, isChecked) {
+                        final todoId = todo.id;
 
-                return Text(context.l10n.noData);
-              },
-            ),
-            AppErrorModalWidget<TodoDetailsBlocType>(
-              errorState: (bloc) => bloc.states.errors,
-            )
+                        if (todoId != null) {
+                          context
+                              .read<TodoActionsBlocType>()
+                              .events
+                              .updateCompletedById(todo.id!, isChecked!);
+                        }
+                      },
+                    );
+                  }
+
+                  return Text(context.l10n.noData);
+                }),
           ],
         ),
       );

--- a/examples/todoapp/lib/feature_todo_details/views/todo_details_page.dart
+++ b/examples/todoapp/lib/feature_todo_details/views/todo_details_page.dart
@@ -68,18 +68,14 @@ class TodoDetailsPage extends StatelessWidget {
                   }
                 },
               ),
-              buildError: (context, error, bloc) => Column(
-                children: [
-                  SizedBox(
-                    height: context.designSystem.spacing.l,
+              buildError: (context, error, bloc) => Padding(
+                padding: EdgeInsets.only(top: context.designSystem.spacing.l),
+                child: Center(
+                  child: AppErrorWidget(
+                    error: error.asErrorModel(),
+                    onTabRetry: () => bloc.events.fetchTodo(),
                   ),
-                  Center(
-                    child: AppErrorWidget(
-                      error: error.asErrorModel(),
-                      onTabRetry: () => bloc.events.fetchTodo(),
-                    ),
-                  ),
-                ],
+                ),
               ),
               buildLoading: (context, bloc) =>
                   const Center(child: AppLoadingIndicator()),

--- a/examples/todoapp/lib/feature_todo_details/views/todo_details_page.dart
+++ b/examples/todoapp/lib/feature_todo_details/views/todo_details_page.dart
@@ -43,7 +43,7 @@ class TodoDetailsPage extends StatelessWidget {
             visible:
                 !(isLoadingSnapshot.hasData && isLoadingSnapshot.requireData),
             child: FloatingActionButton(
-              onPressed: bloc.events.manage,
+              onPressed: bloc.events.updateTodo,
               shape: const OvalBorder(),
               child: context.designSystem.icons.edit,
             ),

--- a/examples/todoapp/lib/feature_todo_list/blocs/todo_list_bloc.dart
+++ b/examples/todoapp/lib/feature_todo_list/blocs/todo_list_bloc.dart
@@ -4,6 +4,7 @@ import 'package:rxdart/rxdart.dart';
 
 import '../../base/common_blocs/coordinator_bloc.dart';
 import '../../base/common_services/todo_list_service.dart';
+import '../../base/extensions/subject_extensions.dart';
 import '../../base/extensions/todo_list_extensions.dart';
 import '../../base/models/todo_model.dart';
 import '../../base/models/todos_filter_model.dart';
@@ -92,9 +93,7 @@ class TodoListBloc extends $TodoListBloc {
   /// Disposes of all streams to prevent memory leaks
   @override
   void dispose() {
-    if(!_todoResult.isClosed) {
-      _todoResult.close();
-    }
+    _todoResult.closeSafely();
     super.dispose();
   }
 }

--- a/examples/todoapp/lib/feature_todo_list/blocs/todo_list_bloc.dart
+++ b/examples/todoapp/lib/feature_todo_list/blocs/todo_list_bloc.dart
@@ -92,7 +92,9 @@ class TodoListBloc extends $TodoListBloc {
   /// Disposes of all streams to prevent memory leaks
   @override
   void dispose() {
-    _todoResult.close();
+    if(!_todoResult.isClosed) {
+      _todoResult.close();
+    }
     super.dispose();
   }
 }

--- a/examples/todoapp/lib/feature_todo_list/ui_components/todo_list_widget.dart
+++ b/examples/todoapp/lib/feature_todo_list/ui_components/todo_list_widget.dart
@@ -37,6 +37,7 @@ class TodoListWidget extends StatelessWidget {
             ),
         child: TodoWidget(
           todo: todos[index],
+          descriptionMaxLines: 1,
           onChanged: (todo, isChecked) {
             if (todo.id != null) {
               context

--- a/examples/todoapp/lib/feature_todo_management/blocs/todo_management_bloc.dart
+++ b/examples/todoapp/lib/feature_todo_management/blocs/todo_management_bloc.dart
@@ -6,6 +6,7 @@ import 'package:rxdart/rxdart.dart';
 import '../../../../base/extensions/error_model_extensions.dart';
 import '../../base/common_blocs/coordinator_bloc.dart';
 import '../../base/common_services/todo_list_service.dart';
+import '../../base/extensions/subject_extensions.dart';
 import '../../base/models/errors/error_model.dart';
 import '../../base/models/todo_model.dart';
 import '../../lib_router/blocs/router_bloc.dart';
@@ -155,9 +156,7 @@ class TodoManagementBloc extends $TodoManagementBloc {
 
   @override
   void dispose() {
-    if (!_todoSubject.isClosed) {
-      _todoSubject.close();
-    }
+    _todoSubject.closeSafely();
     super.dispose();
   }
 }

--- a/examples/todoapp/lib/feature_todo_management/blocs/todo_management_bloc.dart
+++ b/examples/todoapp/lib/feature_todo_management/blocs/todo_management_bloc.dart
@@ -10,7 +10,6 @@ import '../../base/models/errors/error_model.dart';
 import '../../base/models/todo_model.dart';
 import '../../lib_router/blocs/router_bloc.dart';
 import '../../lib_router/router.dart';
-
 import '../services/todo_manage_service.dart';
 import '../services/todo_validator_service.dart';
 
@@ -156,7 +155,9 @@ class TodoManagementBloc extends $TodoManagementBloc {
 
   @override
   void dispose() {
-    _todoSubject.close();
+    if (!_todoSubject.isClosed) {
+      _todoSubject.close();
+    }
     super.dispose();
   }
 }


### PR DESCRIPTION
This PR is addressing the discussed comments in the Todoapp implementation.

It covers the following:
- Added a maxLines attribute to todo's description. This will allow the list and the details to show different number of lines of the details.
- In the todo local data source the naming of the key used for the share preferences is changed.
- Removed the commented code in places it was found.
- Changed the manage event name to be update.
- Perform a check if a subject isn't closed yet before closing it.
- Added error, loading and retry widgets in todo details page.