### PR TITLE
Add content replacement for example project

### DIFF
--- a/packages/rx_bloc_cli/bin/compile_test_project.sh
+++ b/packages/rx_bloc_cli/bin/compile_test_project.sh
@@ -1,17 +1,47 @@
-#!/usr/bin/env sh
+#!/bin/bash
+
+##### Functions
+
+## Replaces the contents of the provided file with some predefined values
+function replace_file_contents() {
+  to_replace=(
+    "docs/continuous_delivery.md" "https://github.com/Prime-Holding/rx_bloc/blob/master/packages/rx_bloc_cli/example/docs/continuous_delivery.md"
+    "docs/golden_tests.md" "https://github.com/Prime-Holding/rx_bloc/blob/master/packages/rx_bloc_cli/example/docs/golden_tests.md"
+  )
+
+  # Iterate over the to_replace array
+  for (( i=1; i<${#to_replace[@]}; i+=2 )); do
+    old_str="${to_replace[$i]}"
+    new_str="${to_replace[$i+1]}"
+
+    # Replace the old string with the new ones in the provided file
+    sed -i '' "s|$old_str|$new_str|g" "$1"
+  done
+}
+
+## Prepares the example directory
+function prepare_example_directory() {
+  # Copy the readme file one level up so that it is visible on the pub.dev page
+  cp example/testapp/README.md example/
+
+  rm -rf example/docs
+  mkdir example/docs
+
+  cp example/testapp/docs/continuous_delivery.md example/docs/
+  cp example/testapp/docs/app_architecture.png example/docs/
+  cp example/testapp/docs/cicd_diagram.png example/docs/
+  cp example/testapp/docs/golden_tests.md example/docs/
+
+  replace_file_contents "example/README.md"
+}
+
+##### Main
 
 . $(dirname "$0")/compile_bundles.sh
-rm -rf example/testapp
-rm -rf example/docs
 
+rm -rf example/testapp
 mkdir example/testapp
+
 $(dirname "$0")/generate_test_project.sh all_enabled
 
-# Copy the readme file one level up so that it is visible on the pub.dev page
-cp example/testapp/README.md example/
-
-mkdir example/docs
-cp example/testapp/docs/continuous_delivery.md example/docs/
-cp example/testapp/docs/app_architecture.png example/docs/
-cp example/testapp/docs/cicd_diagram.png example/docs/
-cp example/testapp/docs/golden_tests.md example/docs/
+prepare_example_directory

--- a/packages/rx_bloc_cli/bin/compile_test_project.sh
+++ b/packages/rx_bloc_cli/bin/compile_test_project.sh
@@ -4,6 +4,7 @@
 
 ## Replaces the contents of the provided file with some predefined values
 function replace_file_contents() {
+  # Values should be specified in pairs, first being the old string and the second being a new one
   to_replace=(
     "docs/continuous_delivery.md" "https://github.com/Prime-Holding/rx_bloc/blob/master/packages/rx_bloc_cli/example/docs/continuous_delivery.md"
     "docs/golden_tests.md" "https://github.com/Prime-Holding/rx_bloc/blob/master/packages/rx_bloc_cli/example/docs/golden_tests.md"
@@ -24,13 +25,12 @@ function prepare_example_directory() {
   # Copy the readme file one level up so that it is visible on the pub.dev page
   cp example/testapp/README.md example/
 
+  # Recreate the example/docs directory
   rm -rf example/docs
   mkdir example/docs
 
-  cp example/testapp/docs/continuous_delivery.md example/docs/
-  cp example/testapp/docs/app_architecture.png example/docs/
-  cp example/testapp/docs/cicd_diagram.png example/docs/
-  cp example/testapp/docs/golden_tests.md example/docs/
+  # Copy the contents of the generated docs directory one level up
+  cp -r example/testapp/docs/ example/docs/
 
   replace_file_contents "example/README.md"
 }


### PR DESCRIPTION
#### Overview

This PR includes a small enhancement for the `compile_test_project` script which automatically replaces specific content for the generated example project in order faster and more consistent updates to the documentation.