### PR TITLE
Fix generated project error when generated with name different than testapp

### DIFF
--- a/packages/rx_bloc_cli/CHANGELOG.md
+++ b/packages/rx_bloc_cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Add a script for running integration tests with Patrol
 * Added a showcase feature that groups all other showcase features in one place
 * Add QR scanner feature as an option under the flag `--enable-feature-qr-scanner`
+* Added `dart fix --apply .` to the project generation process
 * Updates generated project dependencies version
 
 ## [5.1.0]

--- a/packages/rx_bloc_cli/lib/src/commands/create_command.dart
+++ b/packages/rx_bloc_cli/lib/src/commands/create_command.dart
@@ -214,6 +214,18 @@ class CreateCommand extends Command<int> {
 
     _progressFinish(format, progress);
 
+    progress = _logger.progress(
+      'dart fix --apply .',
+    );
+
+    final fix = await Process.run(
+      'dart',
+      ['fix', '--apply', '.'],
+      workingDirectory: outputDirectory.path,
+    );
+
+    _progressFinish(fix, progress);
+
     // Manually create project gitignore after everything is generated
     GitIgnoreCreator.generate(args.outputDirectory.path);
 

--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_showcase/__brick__/lib/l10n/network_lookup/showcase_lookup.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_showcase/__brick__/lib/l10n/network_lookup/showcase_lookup.dart
@@ -1,7 +1,7 @@
 {{> licence.dart }}
 
 import '../../assets.dart';
-import '../testapp_app_i18n.dart';
+import '../{{project_name}}_app_i18n.dart';
 import 'util.dart';
 
 class AppI18nShowcaseLookup extends I18nFeatureShowcaseLookup {


### PR DESCRIPTION
Fix generated project error when generated with a name different than testapp

#### Overview

> Closes: #838 

This PR fixes an issue where the generated project was being generated with an error due to showcase brick. It also introduces a new dart command in the project generation process, that aims to primarily organize imports 

This issue is not related to the issue mentioned in the ticket description but was introduced with the implementation of showcase brick.


As for the:
* [ ] Fix import in test/base/common_ui_components/update_button_golden_test.dart to be not hardcoded to 'testapp', but to take the project's name

After investigating the bricks used to generate new projects, there is no mention of the file  `update_button_golden_test.dart`. Although when I initially generated a new project there was an error, after deleting all the bundles from the `rx_bloc_cli/lib/src/templates`, and regenerating them using the `rx_bloc_cli/bin/compile_bundles.sh` the issue was not present anymore


As for 
 * [ ] Organize imports alphabetically in tests
 
### Proposed solution
The solution is to use the following dart command `dart fix --apply .`. This command automatically applies code changes to the project based on suggestions from the Dart analyzer. It can fix common issues, deprecated APIs, and improve code.


#### Checklist

*Implementation*
- [x] Implementation matches ticket acceptance criteria and technical notes
- [x] Manually tested against Acceptance Criteria
- [x] UI checked in Light / Dark mode

*Stability*
- [x] Checked if changes affect any features and verified affected features work as expected
- [x] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [ ] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [x] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [x] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes