### PR TITLE
Pincode verification page should show only when there's pincode

### DIFF
--- a/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/feature_splash/blocs/splash_bloc.dart
+++ b/packages/rx_bloc_cli/mason_templates/bricks/rx_bloc_base/__brick__/lib/feature_splash/blocs/splash_bloc.dart
@@ -78,7 +78,7 @@ class SplashBloc extends $SplashBloc {
 
       {{#enable_pin_code}}
       if (await _authService.isAuthenticated()) {
-        if (await _pinCodeService.getPinCode() == null) {
+        if (await _pinCodeService.getPinCode() != null) {
           return _navigationBloc.events.go(const VerifyPinCodeRoute(),
               extra: const PinCodeArguments(title: 'Enter Pin Code'));
         }


### PR DESCRIPTION
#### Overview

> Closes: #917 

The pin code page should show only when pincode is not null.
There was small mistake in the splash screen that was showing the pin code page when there was no pin code set.

#### Checklist

*Implementation*
- [x] Implementation matches ticket acceptance criteria and technical notes
- [x] Manually tested against Acceptance Criteria
- [x] UI checked in Light / Dark mode

*Stability*
- [x] Checked if changes affect any features and verified affected features work as expected
- [ ] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [ ] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [ ] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [ ] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes