### PR TITLE
Fix qr scanner camera permission

### DIFF
--- a/packages/rx_bloc_cli/CHANGELOG.md
+++ b/packages/rx_bloc_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [5.4.0]
 * Added `--enable-feature-onboarding` flag to configure an Onboarding/Registration flow for the project, including resuming Onboarding from a different device
+* Fix issue where camera permission was not available on iOS devices for the QR scanner feature
 
 ## [5.3.2]
 * Fix issues in generated project related to pin code and biometrics authentication

--- a/packages/rx_bloc_cli/lib/src/processors/ios/podfile_processor.dart
+++ b/packages/rx_bloc_cli/lib/src/processors/ios/podfile_processor.dart
@@ -70,10 +70,15 @@ class PodfileProcessor extends StringProcessor {
   }
 
   void _addBuildConfigurations(StringBuffer buffer) {
-    String deploymentTargetsConfig;
-    deploymentTargetsConfig = '''\n
+    final deploymentTargetsConfig = '''\n
     target.build_configurations.each do |config|
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '$_minSupportedIOSVersion'
+        ${args.qrScannerEnabled ? '''
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+            '\$(inherited)',
+            ## dart: PermissionGroup.camera
+            'PERMISSION_CAMERA=1',
+        ]''' : ''}
     end
 ''';
     const additionalBuildSettingsConfig =


### PR DESCRIPTION
#### Overview

> Closes: #921 

This PR fixes the QR scanner feature not asking for camera permission on iOS devices

#### Checklist

*Implementation*
- [x] Implementation matches ticket acceptance criteria and technical notes
- [x] Manually tested against Acceptance Criteria
- [x] UI checked in Light / Dark mode

*Stability*
- [x] Checked if changes affect any features and verified affected features work as expected
- [x] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [ ] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [x] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [x] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes