### PR TITLE
Fix fastfile invalid path issue on android

### DIFF
--- a/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
+++ b/packages/rx_bloc_cli/mason_templates/bricks/feature_cicd_fastlane/__brick__/fastlane/Fastfile
@@ -83,6 +83,9 @@ firebase_app_id_map = {
 # Path of the local keychain that is used for iOS builds
 keychain_path = File.join(Dir.getwd, '../devops/credentials/{{project_name.paramCase()}}-distribution.keychain')
 
+# Project path within the repository ending in '/' (used for mono-repo structure, empty otherwise)
+repo_project_path = ""
+
 # ----------------------------------------------------------------------------------------------- #
 
 private_lane :setup_environment_variable do |options|
@@ -286,7 +289,7 @@ platform :android do
             )
         end
 
-        build_output = "apps/<appname>/build/app/outputs"
+        build_output = "#{repo_project_path}build/app/outputs"
         copy_artifacts(
             target_path: "devops/artifacts/",
             artifacts: [


### PR DESCRIPTION
#### Overview

Addresses Fastlane issue where Android build would fail due to incorrect path (assumes specific mono-repo structure).
