### PR TITLE
Fix crash on biometrics switch on iOS physical device

### DIFF
--- a/packages/rx_bloc_cli/lib/src/extensions/string_buffer_extensions.dart
+++ b/packages/rx_bloc_cli/lib/src/extensions/string_buffer_extensions.dart
@@ -37,6 +37,17 @@ extension StringBufferExtensions on StringBuffer {
     return true;
   }
 
+  /// Inserts [content] at the beginning of the first found [pattern] starting
+  /// from the [start] index. Returns `true` if content was successfully
+  /// inserted, `false` otherwise.
+  bool insertBeforeLast(String pattern, String content, [int start = 0]) {
+    final source = toString();
+    final pos = source.lastIndexOf(pattern, start);
+    if (pos < 0) return false;
+    insertAt(pos, content);
+    return true;
+  }
+
   /// Inserts [content] at the end of the first found [pattern] starting
   /// from the [start] index. Returns `true` if content was successfully
   /// inserted, `false` otherwise.

--- a/packages/rx_bloc_cli/lib/src/extensions/string_buffer_extensions.dart
+++ b/packages/rx_bloc_cli/lib/src/extensions/string_buffer_extensions.dart
@@ -37,7 +37,7 @@ extension StringBufferExtensions on StringBuffer {
     return true;
   }
 
-  /// Inserts [content] at the beginning of the first found [pattern] starting
+  /// Inserts [content] at the beginning of the last found [pattern] starting
   /// from the [start] index. Returns `true` if content was successfully
   /// inserted, `false` otherwise.
   bool insertBeforeLast(String pattern, String content, [int start = 0]) {

--- a/packages/rx_bloc_cli/lib/src/processors/ios/info_plist_processor.dart
+++ b/packages/rx_bloc_cli/lib/src/processors/ios/info_plist_processor.dart
@@ -64,6 +64,6 @@ class InfoPlistProcessor extends StringProcessor {
       <string>mailto</string>
     </array>
     ''';
-    buffer.insertBefore('</dict>', _urlSchemes);
+    buffer.insertBeforeLast('</dict>', _urlSchemes);
   }
 }


### PR DESCRIPTION
#### Overview

On biometrics toggle click in the profile page the app was crashing on physical iOS devices.

The problem was that the camera and biometric descriptions were added in the wrong place in the `Info.plist` file. The change in the plist processor was needed.

#### Checklist

*Implementation*
- [ ] Implementation matches ticket acceptance criteria and technical notes
- [ ] Manually tested against Acceptance Criteria
- [ ] UI checked in Light / Dark mode

*Stability*
- [ ] Checked if changes affect any features and verified affected features work as expected
- [ ] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [ ] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [ ] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [ ] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes