### PR TITLE
Update generator deps

### DIFF
--- a/.github/workflows/build_and_test_rx_bloc_packages.yaml
+++ b/.github/workflows/build_and_test_rx_bloc_packages.yaml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         folder:
-          [
-            "examples/booking_app",
-            "examples/counter",
-            "examples/division",
-            "examples/favorites_advanced/rx_bloc_favorites_advanced",
-            "examples/todoapp",
+          [ 
+            "examples/booking_app", 
+            "examples/counter", 
+            "examples/division", 
+            "examples/favorites_advanced/rx_bloc_favorites_advanced", 
+            "examples/todoapp" 
           ]
       fail-fast: false
     runs-on: ubuntu-latest
@@ -52,7 +52,6 @@ jobs:
         working-directory: ${{ matrix.folder }}
         id: check_for_coverage_file
         run: |
-          echo "Passing"
           if [ -s "/coverage/lcov.info" ]; then 
             echo "has_coverage=true" >> $GITHUB_OUTPUT
           else 
@@ -163,12 +162,23 @@ jobs:
       - name: Remove unnecessary files
         working-directory: ${{ matrix.folder }}
         run: dart run clean_coverage clean --exclusions '**/.g.dart','**repository.dart','**rxb.g.dart' coverage/lcov.info
+      - name: Check for existing and non-empty coverage file
+        working-directory: ${{ matrix.folder }}
+        id: check_for_coverage_file
+        run: |
+          if [ -s "/coverage/lcov.info" ]; then 
+            echo "has_coverage=true" >> $GITHUB_OUTPUT
+          else 
+            echo "has_coverage=false" >> $GITHUB_OUTPUT
+          fi
       - name: Check Code Coverage
+        if: steps.check_for_coverage_file.outputs.has_coverage == 'true'
         uses: VeryGoodOpenSource/very_good_coverage@v3
         with:
           path: "${{ matrix.folder }}/coverage/lcov.info"
           min_coverage: 67
       - name: Upload coverage to Codecov
+        if: steps.check_for_coverage_file.outputs.has_coverage == 'true'
         uses: codecov/codecov-action@v4
         with:
           directory: ${{ matrix.folder }}/coverage

--- a/.github/workflows/build_and_test_rx_bloc_packages.yaml
+++ b/.github/workflows/build_and_test_rx_bloc_packages.yaml
@@ -176,7 +176,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: 3.27.4
+          flutter-version: 3.35.7
       - run: dart --version
       - run: flutter --version
       - run: dart pub global activate pana

--- a/.github/workflows/build_and_test_rx_bloc_packages.yaml
+++ b/.github/workflows/build_and_test_rx_bloc_packages.yaml
@@ -64,6 +64,7 @@ jobs:
           path: "${{ matrix.folder }}/coverage/lcov.info"
           min_coverage: 50
       - name: Upload coverage to Codecov
+        if: steps.check_for_coverage_file.outputs.has_coverage == 'true'
         uses: codecov/codecov-action@v4
         with:
           directory: ${{ matrix.folder }}/coverage

--- a/.github/workflows/build_and_test_rx_bloc_packages.yaml
+++ b/.github/workflows/build_and_test_rx_bloc_packages.yaml
@@ -50,10 +50,15 @@ jobs:
         run: flutter pub run clean_coverage clean --exclusions '**.realm.dart','**/*.g.dart','**/di/**','**repository.dart','**/models/**','**/routes.dart','**data_source.dart','**_model.g.dart','**_models.g.dart''**_model.dart','**_model_extensions.dart','**_models.dart','**_models_extensions.dart','**_config.dart','**_constants.dart','**_translations.dart','lib/assets.dart','lib/keys.dart','lib/base/theme/**','lib/base/utils/**','lib/keys.dart','lib/l10n/**' coverage/lcov.info
       - name: Check for existing and non-empty coverage file
         working-directory: ${{ matrix.folder }}
-        id: test_coverage_file
-        run: if [ -s "/coverage/lcov.info" ]; then echo "result=true" >> $GITHUB_OUTPUT ; else echo "result=false" >> $GITHUB_OUTPUT; fi
+        id: check_for_coverage_file
+        run: |
+          if [ -s "/coverage/lcov.info" ]; then 
+            echo "has_coverage=true" >> $GITHUB_OUTPUT
+          else 
+            echo "has_coverage=false" >> $GITHUB_OUTPUT
+          fi
       - name: Check Code Coverage
-        if: steps.test_coverage_file.outputs.result == 'true'
+        if: steps.check_for_coverage_file.outputs.has_coverage == 'true'
         uses: VeryGoodOpenSource/very_good_coverage@v3
         with:
           path: "${{ matrix.folder }}/coverage/lcov.info"

--- a/.github/workflows/build_and_test_rx_bloc_packages.yaml
+++ b/.github/workflows/build_and_test_rx_bloc_packages.yaml
@@ -52,6 +52,7 @@ jobs:
         working-directory: ${{ matrix.folder }}
         id: check_for_coverage_file
         run: |
+          echo "Passing"
           if [ -s "/coverage/lcov.info" ]; then 
             echo "has_coverage=true" >> $GITHUB_OUTPUT
           else 

--- a/.github/workflows/build_and_test_rx_bloc_packages.yaml
+++ b/.github/workflows/build_and_test_rx_bloc_packages.yaml
@@ -48,7 +48,12 @@ jobs:
       - name: Remove unnecessary files
         working-directory: ${{ matrix.folder }}
         run: flutter pub run clean_coverage clean --exclusions '**.realm.dart','**/*.g.dart','**/di/**','**repository.dart','**/models/**','**/routes.dart','**data_source.dart','**_model.g.dart','**_models.g.dart''**_model.dart','**_model_extensions.dart','**_models.dart','**_models_extensions.dart','**_config.dart','**_constants.dart','**_translations.dart','lib/assets.dart','lib/keys.dart','lib/base/theme/**','lib/base/utils/**','lib/keys.dart','lib/l10n/**' coverage/lcov.info
+      - name: Check for existing and non-empty coverage file
+        working-directory: ${{ matrix.folder }}
+        id: test_coverage_file
+        run: if [ -s "/coverage/lcov.info" ]; then echo "result=true" >> $GITHUB_OUTPUT ; else echo "result=false" >> $GITHUB_OUTPUT; fi
       - name: Check Code Coverage
+        if: steps.test_coverage_file.outputs.result == 'true'
         uses: VeryGoodOpenSource/very_good_coverage@v3
         with:
           path: "${{ matrix.folder }}/coverage/lcov.info"

--- a/examples/booking_app/lib/lib_router/routes/routes.dart
+++ b/examples/booking_app/lib/lib_router/routes/routes.dart
@@ -9,7 +9,9 @@ part of '../router.dart';
   ],
 )
 @immutable
-class HomeRoutes extends GoRouteData implements RouteDataModel {
+class HomeRoutes extends GoRouteData
+    with $HomeRoutes
+    implements RouteDataModel {
   const HomeRoutes(this.type);
 
   final NavigationItemType type;
@@ -28,7 +30,9 @@ class HomeRoutes extends GoRouteData implements RouteDataModel {
 }
 
 @immutable
-class HotelDetailsRoutes extends GoRouteData implements RouteDataModel {
+class HotelDetailsRoutes extends GoRouteData
+    with $HotelDetailsRoutes
+    implements RouteDataModel {
   const HotelDetailsRoutes(
     this.type,
     this.id,

--- a/examples/booking_app/pubspec.lock
+++ b/examples/booking_app/pubspec.lock
@@ -5,15 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
+    version: "91.0.0"
   alchemist:
     dependency: "direct dev"
     description:
@@ -26,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "8.4.1"
   animated_stream_list:
     dependency: "direct main"
     description:
@@ -84,10 +79,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: "7174c5d84b0fed00a1f5e7543597b35d67560465ae3d909f0889b8b20419d5e3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "3.0.1"
   build_config:
     dependency: transitive
     description:
@@ -108,26 +103,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      sha256: "82730bf3d9043366ba8c02e4add05842a10739899520a6a22ddbd22d333bd5bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.0.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: "32c6b3d172f1f46b7c4df6bc4a47b8d88afb9e505dd4ace4af80b3c37e89832b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.6.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: "4b188774b369104ad96c0e4ca2471e5162f0566ce277771b179bed5eabf2d048"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.2.1"
   built_collection:
     dependency: transitive
     description:
@@ -140,10 +135,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
+      sha256: "426cf75afdb23aa74bd4e471704de3f9393f3c7b04c1e2d9c6f1073ae0b8b139"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.2"
+    version: "8.12.1"
   characters:
     dependency: transitive
     description:
@@ -284,10 +279,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "3.1.3"
   dbus:
     dependency: transitive
     description:
@@ -441,18 +436,18 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "6f1b756f6e863259a99135ff3c95026c3cdca17d10ebef2bba2261a25ddc8bbc"
+      sha256: c92d18e1fe994cb06d48aa786c46b142a5633067e8297cff6b5a3ac742620104
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "17.0.0"
   go_router_builder:
     dependency: "direct dev"
     description:
       name: go_router_builder
-      sha256: "3425b72dea69209754ac6b71b4da34165dcd4d4a2934713029945709a246427a"
+      sha256: "8f1dd8cc23850dba4223104231682a9410576720cb24693fb0eb925c49b2abe3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
+    version: "4.1.3"
   graphs:
     dependency: transitive
     description:
@@ -585,26 +580,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -621,14 +616,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
@@ -649,10 +636,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -665,10 +652,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
+      sha256: dac24d461418d363778d53198d9ac0510b9d073869f078450f195766ec48d05e
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.4"
+    version: "5.6.1"
   nested:
     dependency: transitive
     description:
@@ -802,7 +789,7 @@ packages:
       path: "../../packages/rx_bloc_generator"
       relative: true
     source: path
-    version: "8.0.1"
+    version: "9.0.0"
   rx_bloc_list:
     dependency: "direct main"
     description:
@@ -882,18 +869,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "07b277b67e0096c45196cbddddf2d8c6ffc49342e88bf31d460ce04605ddac75"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "4.1.1"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.8"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -962,26 +949,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "301b213cd241ca982e9ba50266bd3f5bd1ea33f1455554c5abb85d1be0e2d87e"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.15"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:
@@ -1002,10 +989,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   visibility_detector:
     dependency: transitive
     description:
@@ -1079,5 +1066,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.32.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/examples/booking_app/pubspec.yaml
+++ b/examples/booking_app/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_rx_bloc: any
-  go_router: ^14.2.2
+  go_router: ^17.0.0
   image_picker: ^1.0.1
   intl: ^0.18.1
   provider: ^6.0.0
@@ -35,7 +35,7 @@ dev_dependencies:
   flutter_lints: any
   flutter_test:
     sdk: flutter
-  go_router_builder: ^2.7.0
+  go_router_builder: ^4.1.3
   mockito: ^5.0.0
   patrol: ^3.11.0
   quiver: ^3.0.0

--- a/examples/favorites_advanced/rx_bloc_favorites_advanced/lib/feature_puppy/edit/ui_components/puppy_edit_form.dart
+++ b/examples/favorites_advanced/rx_bloc_favorites_advanced/lib/feature_puppy/edit/ui_components/puppy_edit_form.dart
@@ -15,7 +15,7 @@ class PuppyEditForm extends StatelessWidget {
   const PuppyEditForm({
     Puppy? puppy,
     super.key,
-  })  : _puppy = puppy;
+  }) : _puppy = puppy;
 
   final Puppy? _puppy;
 
@@ -164,40 +164,39 @@ class PuppyEditForm extends StatelessWidget {
         showErrorState: (bloc) => bloc.states.showErrors,
         builder: (fieldState) => Column(
           children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                Row(
-                  children: [
-                    const Text(
-                      'Male',
-                      style: TextStyles.editableTextStyle,
-                    ),
-                    Radio<Gender>(
-                      key: const ValueKey('PuppyGenderMaleRadio'),
-                      value: Gender.Male,
-                      groupValue: fieldState.value,
-                      onChanged: (gender) => fieldState.bloc.events
-                          .setGender(gender ?? Gender.None),
-                    ),
-                  ],
-                ),
-                Row(
-                  children: [
-                    const Text(
-                      'Female',
-                      style: TextStyles.editableTextStyle,
-                    ),
-                    Radio<Gender>(
-                      key: const ValueKey('PuppyGenderFemaleRadio'),
-                      value: Gender.Female,
-                      groupValue: fieldState.value,
-                      onChanged: (gender) => fieldState.bloc.events
-                          .setGender(gender ?? Gender.None),
-                    ),
-                  ],
-                ),
-              ],
+            RadioGroup<Gender>(
+              groupValue: fieldState.value,
+              onChanged: (gender) =>
+                  fieldState.bloc.events.setGender(gender ?? Gender.None),
+              child: const Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        'Male',
+                        style: TextStyles.editableTextStyle,
+                      ),
+                      Radio<Gender>(
+                        key: ValueKey('PuppyGenderMaleRadio'),
+                        value: Gender.Male,
+                      ),
+                    ],
+                  ),
+                  Row(
+                    children: [
+                      Text(
+                        'Female',
+                        style: TextStyles.editableTextStyle,
+                      ),
+                      Radio<Gender>(
+                        key: ValueKey('PuppyGenderFemaleRadio'),
+                        value: Gender.Female,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
             ),
             if (fieldState.showError)
               Row(

--- a/examples/favorites_advanced/rx_bloc_favorites_advanced/pubspec.lock
+++ b/examples/favorites_advanced/rx_bloc_favorites_advanced/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "91.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "8.4.1"
   animated_stream_list_nullsafety:
     dependency: "direct main"
     description:
@@ -70,18 +70,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: c1668065e9ba04752570ad7e038288559d1e2ca5c6d0131c0f5f55e39e777413
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "4.0.3"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
@@ -90,30 +90,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
+      sha256: "110c56ef29b5eb367b4d17fc79375fa8c18a6cd7acd92c05bb3986c17a079057"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.3.1"
+    version: "2.10.4"
   built_collection:
     dependency: transitive
     description:
@@ -126,18 +110,18 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
+      sha256: "426cf75afdb23aa74bd4e471704de3f9393f3c7b04c1e2d9c6f1073ae0b8b139"
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.2"
+    version: "8.12.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -174,10 +158,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -190,39 +174,23 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
-  connectivity:
+    version: "1.19.1"
+  connectivity_plus:
     dependency: transitive
     description:
-      name: connectivity
-      sha256: a8e91263cf3e25fb5cc95e19dfde4999e32a648ac3b9e8a558a28165731678f8
+      name: connectivity_plus
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
-  connectivity_for_web:
+    version: "6.1.5"
+  connectivity_plus_platform_interface:
     dependency: transitive
     description:
-      name: connectivity_for_web
-      sha256: "01a390c1d5adc2ed1fa1f52d120c07fe9fd01166a93f965a832fd6cfc0ea6482"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.0+1"
-  connectivity_macos:
-    dependency: transitive
-    description:
-      name: connectivity_macos
-      sha256: "51ae08d5162eca9669b9d8951ed83ce19c5355a81149f94e4dee2740beb93628"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1+2"
-  connectivity_platform_interface:
-    dependency: transitive
-    description:
-      name: connectivity_platform_interface
-      sha256: "2d82e942df9d49f29a24bb07fb5ce085d4a53e47818c62364d2b6deb9e0d7a8e"
+      name: connectivity_plus_platform_interface
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
@@ -278,10 +246,18 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.6"
+    version: "3.1.3"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   equatable:
     dependency: transitive
     description:
@@ -294,10 +270,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   favorites_advanced_base:
     dependency: "direct main"
     description:
@@ -305,6 +281,14 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -555,26 +539,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -595,10 +579,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -611,10 +595,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -627,10 +611,10 @@ packages:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
+      sha256: dac24d461418d363778d53198d9ac0510b9d073869f078450f195766ec48d05e
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.4"
+    version: "5.6.1"
   nested:
     dependency: transitive
     description:
@@ -639,6 +623,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:
@@ -659,10 +651,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -725,21 +725,21 @@ packages:
       path: "../../../packages/rx_bloc"
       relative: true
     source: path
-    version: "6.0.0"
+    version: "6.0.1"
   rx_bloc_generator:
     dependency: "direct dev"
     description:
       path: "../../../packages/rx_bloc_generator"
       relative: true
     source: path
-    version: "8.0.0"
+    version: "9.0.0"
   rx_bloc_list:
     dependency: "direct main"
     description:
       path: "../../../packages/rx_bloc_list"
       relative: true
     source: path
-    version: "5.0.0"
+    version: "5.0.1"
   rx_bloc_test:
     dependency: "direct dev"
     description:
@@ -799,7 +799,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   smooth_star_rating_null_safety:
     dependency: transitive
     description:
@@ -812,10 +812,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "07b277b67e0096c45196cbddddf2d8c6ffc49342e88bf31d460ce04605ddac75"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "4.1.1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -844,18 +844,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -884,34 +884,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.7"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -924,10 +916,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   visibility_detector:
     dependency: transitive
     description:
@@ -976,6 +968,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
@@ -985,5 +985,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/examples/favorites_advanced/rx_bloc_favorites_advanced/pubspec.yaml
+++ b/examples/favorites_advanced/rx_bloc_favorites_advanced/pubspec.yaml
@@ -27,11 +27,11 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.11
+  clean_coverage: ^0.0.3
+  flutter_lints: any
   flutter_test:
     sdk: flutter
 #  test: 1.15.2
-  clean_coverage: ^0.0.3
-  flutter_lints: any
 #  flutter_gherkin: ^1.1.9
   mockito: ^5.4.2
   quiver: ^3.0.1+1

--- a/examples/todoapp/pubspec.yaml
+++ b/examples/todoapp/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
 
 dev_dependencies:
   alchemist: ^0.12.0
-  analyzer: 6.9.0
+  analyzer: ^8.0.1
   build_runner: ^2.4.13
   clean_coverage: ^0.0.3
   copy_with_extension_gen: ^5.0.4
@@ -55,7 +55,7 @@ dev_dependencies:
   mockito: ^5.4.4
   patrol: ^3.11.2 
   r_flutter: 0.9.0
-  retrofit_generator: ^8.2.1
+  retrofit_generator: ^10.2.0
   rx_bloc_generator: ^8.0.0
   rx_bloc_test: ^5.0.0
   test: any

--- a/examples/todoapp/pubspec_overrides.yaml
+++ b/examples/todoapp/pubspec_overrides.yaml
@@ -12,13 +12,13 @@ dependency_overrides:
       path: packages/alice_dio
   ## TODO: Temporary fix until [this issue](https://github.com/realm/realm-dart/issues/1811) is closed
   source_span: 1.10.0
-  #rx_bloc_test:
-  #  path: ../../packages/rx_bloc_test
-  #rx_bloc:
-  #  path: ../../packages/rx_bloc
-  #flutter_rx_bloc:
-  #  path: ../../packages/flutter_rx_bloc
-  #rx_bloc_generator:
-  #  path: ../../packages/rx_bloc_generator
-  #rx_bloc_list:
-  #  path: ../../packages/rx_bloc_list
+  rx_bloc_test:
+    path: ../../packages/rx_bloc_test
+  rx_bloc:
+    path: ../../packages/rx_bloc
+  flutter_rx_bloc:
+    path: ../../packages/flutter_rx_bloc
+  rx_bloc_generator:
+    path: ../../packages/rx_bloc_generator
+  rx_bloc_list:
+    path: ../../packages/rx_bloc_list

--- a/packages/rx_bloc_generator/CHANGELOG.md
+++ b/packages/rx_bloc_generator/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [8.0.2]
+* Update dependencies to the latest versions
+
 ## [8.0.1]
 * Update dependencies to the latest versions
 

--- a/packages/rx_bloc_generator/CHANGELOG.md
+++ b/packages/rx_bloc_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [8.0.2]
+## [9.0.0]
 * Update dependencies to the latest versions
 
 ## [8.0.1]

--- a/packages/rx_bloc_generator/lib/rx_bloc_generator.dart
+++ b/packages/rx_bloc_generator/lib/rx_bloc_generator.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element2.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/dart/element/element.dart';
+
 import 'package:build/build.dart';
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:code_builder/code_builder.dart';

--- a/packages/rx_bloc_generator/lib/rx_bloc_generator.dart
+++ b/packages/rx_bloc_generator/lib/rx_bloc_generator.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:analyzer/dart/constant/value.dart';
-import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:build/build.dart';
 // ignore: import_of_legacy_library_into_null_safe

--- a/packages/rx_bloc_generator/lib/src/build_controller.dart
+++ b/packages/rx_bloc_generator/lib/src/build_controller.dart
@@ -1,8 +1,5 @@
 part of '../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
 /// Validates the main bloc file and provides the generator the needed data
 class _BuildController {
   _BuildController({
@@ -11,9 +8,9 @@ class _BuildController {
     required this.stateClass,
   });
 
-  final ClassElement rxBlocClass;
-  final ClassElement? eventClass;
-  final ClassElement? stateClass;
+  final ClassElement2 rxBlocClass;
+  final ClassElement2? eventClass;
+  final ClassElement2? stateClass;
 
   String generate() {
     // Check for any broken rules
@@ -21,7 +18,7 @@ class _BuildController {
 
     final blocTypeClassName = '${rxBlocClass.displayName}Type';
     final blocClassGenericTypes =
-        rxBlocClass.typeParameters.map((final t) => t.displayName);
+        rxBlocClass.typeParameters2.map((final t) => t.displayName);
     final blocClassGenericTypesString = blocClassGenericTypes.isNotEmpty
         ? '<${blocClassGenericTypes.join(', ')}>'
         : '';
@@ -29,7 +26,8 @@ class _BuildController {
         '\$${rxBlocClass.displayName}$blocClassGenericTypesString';
     final eventClassName = eventClass!.displayName;
     final stateClassName = stateClass!.displayName;
-    final blocFilePath = rxBlocClass.location?.components.first ?? '';
+    final blocFilePath =
+        rxBlocClass.firstFragment.libraryFragment.source.uri.path;
     final mainBlocFileName =
         Uri.tryParse(blocFilePath, (blocFilePath.lastIndexOf('/') + 1))
                 ?.toString() ??
@@ -55,22 +53,22 @@ class _BuildController {
         blocTypeClassName,
         eventClassName,
         stateClassName,
-        eventClass!.methods,
-        stateClass!.fields
+        eventClass!.methods2,
+        stateClass!.fields2
             // Skip @RxBlocIgnoreState() ignored states
-            .where((FieldElement field) =>
-                field.getter is PropertyAccessorElement &&
-                field.getter != null &&
-                (field.getter!.metadata.isEmpty ||
-                    !const TypeChecker.fromRuntime(RxBlocIgnoreState)
-                        .hasAnnotationOf(field.getter!)))
+            .where((FieldElement2 field) =>
+                field.getter2 is PropertyAccessorElement2 &&
+                field.getter2 != null &&
+                (field.getter2!.metadata2.annotations.isEmpty ||
+                    !const TypeChecker.typeNamed(RxBlocIgnoreState)
+                        .hasAnnotationOf(field.getter2!)))
             .toList(),
       ).build().toDartCodeString(),
 
       // typedef _[EventMethodName]EventArgs
-      ...eventClass!.methods
-          .where((MethodElement method) => method.isUsingRecord)
-          .map((MethodElement method) {
+      ...eventClass!.methods2
+          .where((MethodElement2 method) => method.isUsingRecord)
+          .map((MethodElement2 method) {
         return method.argsRecord.typeDef().toDartCodeString();
       })
     ].forEach(output.writeln);
@@ -90,16 +88,16 @@ class _BuildController {
       throw _RxBlocGeneratorException(
         _generateMissingClassError(
           eventClass?.displayName ?? '',
-          rxBlocClass.name,
+          rxBlocClass.name3 ?? '',
         ),
       );
     }
 
     // Methods only - No fields should exist
-    for (var field in eventClass!.fields) {
+    for (var field in eventClass!.fields2) {
       throw _RxBlocGeneratorException(
-          '${eventClass!.name} should contain methods only,'
-          ' while ${field.name} seems to be a field.');
+          '${eventClass!.name3} should contain methods only,'
+          ' while ${field.name3} seems to be a field.');
     }
   }
 
@@ -109,20 +107,20 @@ class _BuildController {
       throw _RxBlocGeneratorException(
         _generateMissingClassError(
           eventClass?.displayName ?? '',
-          rxBlocClass.name,
+          rxBlocClass.name3 ?? '',
         ),
       );
     }
 
     // Fields only - No methods should exist
-    for (var method in stateClass!.methods) {
+    for (var method in stateClass!.methods2) {
       throw _RxBlocGeneratorException(
-          'State ${method.name} should be defined using the get keyword.');
+          'State ${method.name3} should be defined using the get keyword.');
     }
 
-    for (var fieldElement in stateClass!.accessors) {
-      if (!fieldElement.isAbstract) {
-        final name = fieldElement.name.replaceAll('=', '');
+    for (var fieldElement in stateClass!.fields2) {
+      if (!(fieldElement.getter2?.isAbstract ?? false)) {
+        final name = fieldElement.name3?.replaceAll('=', '');
         throw _RxBlocGeneratorException(
             'State $name should not contain a body definition.');
       }

--- a/packages/rx_bloc_generator/lib/src/build_controller.dart
+++ b/packages/rx_bloc_generator/lib/src/build_controller.dart
@@ -8,17 +8,18 @@ class _BuildController {
     required this.stateClass,
   });
 
-  final ClassElement2 rxBlocClass;
-  final ClassElement2? eventClass;
-  final ClassElement2? stateClass;
+  final ClassElement rxBlocClass;
+  final ClassElement? eventClass;
+  final ClassElement? stateClass;
 
   String generate() {
     // Check for any broken rules
     _validate();
 
     final blocTypeClassName = '${rxBlocClass.displayName}Type';
-    final blocClassGenericTypes =
-        rxBlocClass.typeParameters2.map((final t) => t.displayName);
+    final blocClassGenericTypes = rxBlocClass.typeParameters.map(
+      (final t) => t.displayName,
+    );
     final blocClassGenericTypesString = blocClassGenericTypes.isNotEmpty
         ? '<${blocClassGenericTypes.join(', ')}>'
         : '';
@@ -29,9 +30,11 @@ class _BuildController {
     final blocFilePath =
         rxBlocClass.firstFragment.libraryFragment.source.uri.path;
     final mainBlocFileName =
-        Uri.tryParse(blocFilePath, (blocFilePath.lastIndexOf('/') + 1))
-                ?.toString() ??
-            '';
+        Uri.tryParse(
+          blocFilePath,
+          (blocFilePath.lastIndexOf('/') + 1),
+        )?.toString() ??
+        '';
 
     /// The output buffer containing all the generated code
     final output = StringBuffer();
@@ -53,24 +56,27 @@ class _BuildController {
         blocTypeClassName,
         eventClassName,
         stateClassName,
-        eventClass!.methods2,
-        stateClass!.fields2
+        eventClass!.methods,
+        stateClass!.fields
             // Skip @RxBlocIgnoreState() ignored states
-            .where((FieldElement2 field) =>
-                field.getter2 is PropertyAccessorElement2 &&
-                field.getter2 != null &&
-                (field.getter2!.metadata2.annotations.isEmpty ||
-                    !const TypeChecker.typeNamed(RxBlocIgnoreState)
-                        .hasAnnotationOf(field.getter2!)))
+            .where(
+              (FieldElement field) =>
+                  field.getter is PropertyAccessorElement &&
+                  field.getter != null &&
+                  (field.getter!.metadata.annotations.isEmpty ||
+                      !const TypeChecker.typeNamed(
+                        RxBlocIgnoreState,
+                      ).hasAnnotationOf(field.getter!)),
+            )
             .toList(),
       ).build().toDartCodeString(),
 
       // typedef _[EventMethodName]EventArgs
-      ...eventClass!.methods2
-          .where((MethodElement2 method) => method.isUsingRecord)
-          .map((MethodElement2 method) {
-        return method.argsRecord.typeDef().toDartCodeString();
-      })
+      ...eventClass!.methods
+          .where((MethodElement method) => method.isUsingRecord)
+          .map((MethodElement method) {
+            return method.argsRecord.typeDef().toDartCodeString();
+          }),
     ].forEach(output.writeln);
 
     return output.toString();
@@ -88,16 +94,17 @@ class _BuildController {
       throw _RxBlocGeneratorException(
         _generateMissingClassError(
           eventClass?.displayName ?? '',
-          rxBlocClass.name3 ?? '',
+          rxBlocClass.name ?? '',
         ),
       );
     }
 
     // Methods only - No fields should exist
-    for (var field in eventClass!.fields2) {
+    for (var field in eventClass!.fields) {
       throw _RxBlocGeneratorException(
-          '${eventClass!.name3} should contain methods only,'
-          ' while ${field.name3} seems to be a field.');
+        '${eventClass!.name} should contain methods only,'
+        ' while ${field.name} seems to be a field.',
+      );
     }
   }
 
@@ -107,22 +114,24 @@ class _BuildController {
       throw _RxBlocGeneratorException(
         _generateMissingClassError(
           eventClass?.displayName ?? '',
-          rxBlocClass.name3 ?? '',
+          rxBlocClass.name ?? '',
         ),
       );
     }
 
     // Fields only - No methods should exist
-    for (var method in stateClass!.methods2) {
+    for (var method in stateClass!.methods) {
       throw _RxBlocGeneratorException(
-          'State ${method.name3} should be defined using the get keyword.');
+        'State ${method.name} should be defined using the get keyword.',
+      );
     }
 
-    for (var fieldElement in stateClass!.fields2) {
-      if (!(fieldElement.getter2?.isAbstract ?? false)) {
-        final name = fieldElement.name3?.replaceAll('=', '');
+    for (var fieldElement in stateClass!.fields) {
+      if (!(fieldElement.getter?.isAbstract ?? false)) {
+        final name = fieldElement.name?.replaceAll('=', '');
         throw _RxBlocGeneratorException(
-            'State $name should not contain a body definition.');
+          'State $name should not contain a body definition.',
+        );
       }
     }
   }
@@ -134,11 +143,10 @@ class _BuildController {
   /// the user-defined or the default value for the events/states class that
   /// is vital for proper bloc generation.
   String _generateMissingClassError(String className, String blocName) =>
-      (StringBuffer()
-            ..writeAll(<String>[
-              '$blocName$className class missing.',
-              'Please make sure you have properly named and specified',
-              'your class in the same file where the $blocName resides.'
-            ], '\n\t'))
+      (StringBuffer()..writeAll(<String>[
+            '$blocName$className class missing.',
+            'Please make sure you have properly named and specified',
+            'your class in the same file where the $blocName resides.',
+          ], '\n\t'))
           .toString();
 }

--- a/packages/rx_bloc_generator/lib/src/builders/bloc_class.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/bloc_class.dart
@@ -1,8 +1,5 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
 /// Generates the content of the blocClass
 ///
 /// Example:
@@ -38,9 +35,9 @@ class _BlocClass implements _BuilderContract {
 
   final String stateClassName;
 
-  final List<MethodElement> eventsMethods;
+  final List<MethodElement2> eventsMethods;
 
-  final List<FieldElement> statesFields;
+  final List<FieldElement2> statesFields;
 
   @override
   Class build() => Class(
@@ -65,30 +62,30 @@ class _BlocClass implements _BuilderContract {
             // Example:
             // final _${eventName}Event = PublishSubject<void>();
             ...eventsMethods
-                .map((MethodElement method) => _EventField(method).build()),
+                .map((MethodElement2 method) => _EventField(method).build()),
 
             // Example:
             // Stream<int> _{stateName}State;
             ...statesFields
-                .map((FieldElement field) => _StateField(field).build()),
+                .map((FieldElement2 field) => _StateField(field).build()),
           ])
           ..methods.addAll(
             <Method>[
               // Example:
               // void {eventName}() => _${eventName}Event.add(null);
               ...eventsMethods
-                  .map((MethodElement method) => _EventMethod(method).build()),
+                  .map((MethodElement2 method) => _EventMethod(method).build()),
 
               // Example:
               // Stream<int> get {stateName} =>
               //      _{stateName}State ??= _mapTo{StateName}State();
               ...statesFields.map(
-                  (FieldElement field) => _StateGetterMethod(field).build()),
+                  (FieldElement2 field) => _StateGetterMethod(field).build()),
 
               // Example:
               // Stream<int> _mapTo{StateName}State();
               ...statesFields
-                  .map((FieldElement field) => _StateMethod(field).build()),
+                  .map((FieldElement2 field) => _StateMethod(field).build()),
 
               // Example:
               // {BlocName}BlocEvents get events => this;

--- a/packages/rx_bloc_generator/lib/src/builders/bloc_class.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/bloc_class.dart
@@ -35,75 +35,76 @@ class _BlocClass implements _BuilderContract {
 
   final String stateClassName;
 
-  final List<MethodElement2> eventsMethods;
+  final List<MethodElement> eventsMethods;
 
-  final List<FieldElement2> statesFields;
+  final List<FieldElement> statesFields;
 
   @override
   Class build() => Class(
-        (b) => b
-          ..docs.addAll(<String>[
-            '/// [$className] extended by the [${className.substring(1)}]',
-            '/// @nodoc',
-          ])
-          ..abstract = true
-          ..name = className
-          ..extend = refer((RxBlocBase).toString())
-          ..implements.addAll(<Reference>[
-            refer(eventClassName),
-            refer(stateClassName),
-            refer(blocTypeClassName),
-          ])
-          ..fields.addAll(<Field>[
-            // Example:
-            // final _compositeSubscription = CompositeSubscription();
-            _CompositionField().build(),
+    (b) => b
+      ..docs.addAll(<String>[
+        '/// [$className] extended by the [${className.substring(1)}]',
+        '/// @nodoc',
+      ])
+      ..abstract = true
+      ..name = className
+      ..extend = refer((RxBlocBase).toString())
+      ..implements.addAll(<Reference>[
+        refer(eventClassName),
+        refer(stateClassName),
+        refer(blocTypeClassName),
+      ])
+      ..fields.addAll(<Field>[
+        // Example:
+        // final _compositeSubscription = CompositeSubscription();
+        _CompositionField().build(),
 
-            // Example:
-            // final _${eventName}Event = PublishSubject<void>();
-            ...eventsMethods
-                .map((MethodElement2 method) => _EventField(method).build()),
+        // Example:
+        // final _${eventName}Event = PublishSubject<void>();
+        ...eventsMethods.map(
+          (MethodElement method) => _EventField(method).build(),
+        ),
 
-            // Example:
-            // Stream<int> _{stateName}State;
-            ...statesFields
-                .map((FieldElement2 field) => _StateField(field).build()),
-          ])
-          ..methods.addAll(
-            <Method>[
-              // Example:
-              // void {eventName}() => _${eventName}Event.add(null);
-              ...eventsMethods
-                  .map((MethodElement2 method) => _EventMethod(method).build()),
+        // Example:
+        // Stream<int> _{stateName}State;
+        ...statesFields.map((FieldElement field) => _StateField(field).build()),
+      ])
+      ..methods.addAll(<Method>[
+        // Example:
+        // void {eventName}() => _${eventName}Event.add(null);
+        ...eventsMethods.map(
+          (MethodElement method) => _EventMethod(method).build(),
+        ),
 
-              // Example:
-              // Stream<int> get {stateName} =>
-              //      _{stateName}State ??= _mapTo{StateName}State();
-              ...statesFields.map(
-                  (FieldElement2 field) => _StateGetterMethod(field).build()),
+        // Example:
+        // Stream<int> get {stateName} =>
+        //      _{stateName}State ??= _mapTo{StateName}State();
+        ...statesFields.map(
+          (FieldElement field) => _StateGetterMethod(field).build(),
+        ),
 
-              // Example:
-              // Stream<int> _mapTo{StateName}State();
-              ...statesFields
-                  .map((FieldElement2 field) => _StateMethod(field).build()),
+        // Example:
+        // Stream<int> _mapTo{StateName}State();
+        ...statesFields.map(
+          (FieldElement field) => _StateMethod(field).build(),
+        ),
 
-              // Example:
-              // {BlocName}BlocEvents get events => this;
-              _StaticStateGetterMethod(eventClassName, true).build(),
+        // Example:
+        // {BlocName}BlocEvents get events => this;
+        _StaticStateGetterMethod(eventClassName, true).build(),
 
-              // Example:
-              // {BlocName}BlocStates get states => this;
-              _StaticStateGetterMethod(stateClassName, false).build(),
+        // Example:
+        // {BlocName}BlocStates get states => this;
+        _StaticStateGetterMethod(stateClassName, false).build(),
 
-              // Example:
-              // void dispose() {
-              //   .._${eventMethod1}Event.close();
-              //   .._${eventMethod2}Event.close();
-              //   ...
-              //   ..super.dispose();
-              // }
-              _DisposeMethod(eventsMethods).build(),
-            ],
-          ),
-      );
+        // Example:
+        // void dispose() {
+        //   .._${eventMethod1}Event.close();
+        //   .._${eventMethod2}Event.close();
+        //   ...
+        //   ..super.dispose();
+        // }
+        _DisposeMethod(eventsMethods).build(),
+      ]),
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/builders/composition_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/composition_field.dart
@@ -1,9 +1,6 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
-/// A mapper that converts a [FieldElement] into an event [Field]
+/// A mapper that converts a [FieldElement2] into an event [Field]
 class _CompositionField implements _BuilderContract {
   @override
   Field build() => Field(

--- a/packages/rx_bloc_generator/lib/src/builders/composition_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/composition_field.dart
@@ -1,14 +1,12 @@
 part of '../../rx_bloc_generator.dart';
 
-/// A mapper that converts a [FieldElement2] into an event [Field]
+/// A mapper that converts a [FieldElement] into an event [Field]
 class _CompositionField implements _BuilderContract {
   @override
   Field build() => Field(
-        (b) => b
-          ..modifier = FieldModifier.final$
-          ..name = '_compositeSubscription'
-          ..assignment = refer('CompositeSubscription').newInstance(
-            [],
-          ).code,
-      );
+    (b) => b
+      ..modifier = FieldModifier.final$
+      ..name = '_compositeSubscription'
+      ..assignment = refer('CompositeSubscription').newInstance([]).code,
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/builders/dispose_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/dispose_method.dart
@@ -1,8 +1,5 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
 /// Builds the dispose method
 /// Example:
 ///
@@ -15,7 +12,7 @@ part of '../../rx_bloc_generator.dart';
 class _DisposeMethod implements _BuilderContract {
   const _DisposeMethod(this.eventMethods);
 
-  final List<MethodElement> eventMethods;
+  final List<MethodElement2> eventMethods;
 
   @override
   Method build() => Method.returnsVoid(
@@ -26,7 +23,7 @@ class _DisposeMethod implements _BuilderContract {
           ..body = CodeExpression(
             Block.of([
               ...eventMethods.map(
-                (MethodElement method) =>
+                (MethodElement2 method) =>
                     refer('${method.eventFieldName}.close').call([]).statement,
               ),
               refer('_compositeSubscription.dispose').call([]).statement,

--- a/packages/rx_bloc_generator/lib/src/builders/dispose_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/dispose_method.dart
@@ -12,23 +12,23 @@ part of '../../rx_bloc_generator.dart';
 class _DisposeMethod implements _BuilderContract {
   const _DisposeMethod(this.eventMethods);
 
-  final List<MethodElement2> eventMethods;
+  final List<MethodElement> eventMethods;
 
   @override
   Method build() => Method.returnsVoid(
-        (b) => b
-          ..docs.addAll(['']) // A new line
-          ..annotations.add(refer('override'))
-          ..name = 'dispose'
-          ..body = CodeExpression(
-            Block.of([
-              ...eventMethods.map(
-                (MethodElement2 method) =>
-                    refer('${method.eventFieldName}.close').call([]).statement,
-              ),
-              refer('_compositeSubscription.dispose').call([]).statement,
-              refer('super.dispose').call([]).statement,
-            ]),
-          ).code,
-      );
+    (b) => b
+      ..docs.addAll(['']) // A new line
+      ..annotations.add(refer('override'))
+      ..name = 'dispose'
+      ..body = CodeExpression(
+        Block.of([
+          ...eventMethods.map(
+            (MethodElement method) =>
+                refer('${method.eventFieldName}.close').call([]).statement,
+          ),
+          refer('_compositeSubscription.dispose').call([]).statement,
+          refer('super.dispose').call([]).statement,
+        ]),
+      ).code,
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/builders/event_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/event_field.dart
@@ -1,23 +1,20 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
-/// A mapper that converts a [MethodElement] into an event [Field]
+/// A mapper that converts a [MethodElement2] into an event [Field]
 class _EventField implements _BuilderContract {
   const _EventField(this.method);
 
-  final MethodElement method;
+  final MethodElement2 method;
 
   @override
   Field build() => Field(
         (b) => b
           ..docs.addAll(<String>[
-            if (method.name.length <= 26)
-              '/// Тhe [Subject] where events sink to by calling [${method.name}]',
-            if (method.name.length > 26) ...<String>[
+            if ((method.name3?.length ?? 0) <= 26)
+              '/// Тhe [Subject] where events sink to by calling [${method.name3}]',
+            if ((method.name3?.length ?? 0) > 26) ...<String>[
               '/// Тhe [Subject] where events sink to by calling ',
-              '/// [${method.name}]'
+              '/// [${method.name3}]'
             ],
           ])
           ..modifier = FieldModifier.final$

--- a/packages/rx_bloc_generator/lib/src/builders/event_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/event_field.dart
@@ -1,32 +1,30 @@
 part of '../../rx_bloc_generator.dart';
 
-/// A mapper that converts a [MethodElement2] into an event [Field]
+/// A mapper that converts a [MethodElement] into an event [Field]
 class _EventField implements _BuilderContract {
   const _EventField(this.method);
 
-  final MethodElement2 method;
+  final MethodElement method;
 
   @override
   Field build() => Field(
-        (b) => b
-          ..docs.addAll(<String>[
-            if ((method.name3?.length ?? 0) <= 26)
-              '/// Тhe [Subject] where events sink to by calling [${method.name3}]',
-            if ((method.name3?.length ?? 0) > 26) ...<String>[
-              '/// Тhe [Subject] where events sink to by calling ',
-              '/// [${method.name3}]'
-            ],
-          ])
-          ..modifier = FieldModifier.final$
-          ..assignment = method.hasSeedAnnotation
-              ? refer(method.eventStreamType)
-                  .newInstanceNamed(
-                    'seeded',
-                    method.seedPositionalArguments,
-                  )
-                  .code
-              : refer(method.eventStreamType)
-                  .newInstance([], {}, method.streamTypeArguments).code
-          ..name = method.eventFieldName,
-      );
+    (b) => b
+      ..docs.addAll(<String>[
+        if ((method.name?.length ?? 0) <= 26)
+          '/// Тhe [Subject] where events sink to by calling [${method.name}]',
+        if ((method.name?.length ?? 0) > 26) ...<String>[
+          '/// Тhe [Subject] where events sink to by calling ',
+          '/// [${method.name}]',
+        ],
+      ])
+      ..modifier = FieldModifier.final$
+      ..assignment = method.hasSeedAnnotation
+          ? refer(
+              method.eventStreamType,
+            ).newInstanceNamed('seeded', method.seedPositionalArguments).code
+          : refer(
+              method.eventStreamType,
+            ).newInstance([], {}, method.streamTypeArguments).code
+      ..name = method.eventFieldName,
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/builders/event_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/event_method.dart
@@ -1,24 +1,24 @@
 part of '../../rx_bloc_generator.dart';
 
-/// A mapper that converts a [MethodElement2] into an event [Method]
+/// A mapper that converts a [MethodElement] into an event [Method]
 class _EventMethod implements _BuilderContract {
   const _EventMethod(this.method);
 
-  final MethodElement2 method;
+  final MethodElement method;
 
   @override
   Method build() => Method.returnsVoid(
-        (b) => b
-          ..docs.addAll(['']) // A new line
-          ..annotations.add(
-            refer('override'),
-          )
-          ..name = method.name3
-          ..requiredParameters
-              .addAll(method.formalParameters.whereRequired().clone())
-          ..optionalParameters
-              .addAll(method.formalParameters.whereOptional().clone())
-          ..lambda = true
-          ..body = method.buildBody(),
-      );
+    (b) => b
+      ..docs.addAll(['']) // A new line
+      ..annotations.add(refer('override'))
+      ..name = method.name
+      ..requiredParameters.addAll(
+        method.formalParameters.whereRequired().clone(),
+      )
+      ..optionalParameters.addAll(
+        method.formalParameters.whereOptional().clone(),
+      )
+      ..lambda = true
+      ..body = method.buildBody(),
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/builders/event_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/event_method.dart
@@ -1,13 +1,10 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
-/// A mapper that converts a [MethodElement] into an event [Method]
+/// A mapper that converts a [MethodElement2] into an event [Method]
 class _EventMethod implements _BuilderContract {
   const _EventMethod(this.method);
 
-  final MethodElement method;
+  final MethodElement2 method;
 
   @override
   Method build() => Method.returnsVoid(
@@ -16,9 +13,11 @@ class _EventMethod implements _BuilderContract {
           ..annotations.add(
             refer('override'),
           )
-          ..name = method.name
-          ..requiredParameters.addAll(method.parameters.whereRequired().clone())
-          ..optionalParameters.addAll(method.parameters.whereOptional().clone())
+          ..name = method.name3
+          ..requiredParameters
+              .addAll(method.formalParameters.whereRequired().clone())
+          ..optionalParameters
+              .addAll(method.formalParameters.whereOptional().clone())
           ..lambda = true
           ..body = method.buildBody(),
       );

--- a/packages/rx_bloc_generator/lib/src/builders/state_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_field.dart
@@ -1,27 +1,24 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
-/// A mapper that converts a [FieldElement] into an event [Field]
+/// A mapper that converts a [FieldElement2] into an event [Field]
 class _StateField implements _BuilderContract {
   const _StateField(this.field);
 
-  final FieldElement field;
+  final FieldElement2 field;
 
   @override
   Field build() => Field(
         (b) => b
           ..docs.addAll(<String>[
-            if (field.name.length <= 15)
-              '/// The state of [${field.name}] implemented in [${field.stateMethodName}]',
-            if (field.name.length > 15) ...<String>[
-              '/// The state of [${field.name}] implemented in ',
+            if ((field.name3?.length ?? 0) <= 15)
+              '/// The state of [${field.name3}] implemented in [${field.stateMethodName}]',
+            if ((field.name3?.length ?? 0) > 15) ...<String>[
+              '/// The state of [${field.name3}] implemented in ',
               '/// [${field.stateMethodName}]'
             ]
           ])
           ..type = refer(
-            'late final ${field.type.getDisplayString(withNullability: true)}',
+            'late final ${field.type.getDisplayString()}',
           )
           ..assignment = refer(field.stateMethodName).newInstance([]).code
           ..name = field.stateFieldName,

--- a/packages/rx_bloc_generator/lib/src/builders/state_field.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_field.dart
@@ -1,26 +1,24 @@
 part of '../../rx_bloc_generator.dart';
 
-/// A mapper that converts a [FieldElement2] into an event [Field]
+/// A mapper that converts a [FieldElement] into an event [Field]
 class _StateField implements _BuilderContract {
   const _StateField(this.field);
 
-  final FieldElement2 field;
+  final FieldElement field;
 
   @override
   Field build() => Field(
-        (b) => b
-          ..docs.addAll(<String>[
-            if ((field.name3?.length ?? 0) <= 15)
-              '/// The state of [${field.name3}] implemented in [${field.stateMethodName}]',
-            if ((field.name3?.length ?? 0) > 15) ...<String>[
-              '/// The state of [${field.name3}] implemented in ',
-              '/// [${field.stateMethodName}]'
-            ]
-          ])
-          ..type = refer(
-            'late final ${field.type.getDisplayString()}',
-          )
-          ..assignment = refer(field.stateMethodName).newInstance([]).code
-          ..name = field.stateFieldName,
-      );
+    (b) => b
+      ..docs.addAll(<String>[
+        if ((field.name?.length ?? 0) <= 15)
+          '/// The state of [${field.name}] implemented in [${field.stateMethodName}]',
+        if ((field.name?.length ?? 0) > 15) ...<String>[
+          '/// The state of [${field.name}] implemented in ',
+          '/// [${field.stateMethodName}]',
+        ],
+      ])
+      ..type = refer('late final ${field.type.getDisplayString()}')
+      ..assignment = refer(field.stateMethodName).newInstance([]).code
+      ..name = field.stateFieldName,
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
@@ -1,20 +1,20 @@
 part of '../../rx_bloc_generator.dart';
 
-/// A mapper that converts a [MethodElement2] into an event [Method]
+/// A mapper that converts a [MethodElement] into an event [Method]
 class _StateGetterMethod implements _BuilderContract {
   const _StateGetterMethod(this.field);
 
-  final FieldElement2 field;
+  final FieldElement field;
 
   @override
   Method build() => Method(
-        (b) => b
-          ..docs.addAll(['']) // A new line
-          ..type = MethodType.getter
-          ..annotations.add(refer('override'))
-          ..returns = refer(field.type.getDisplayString())
-          ..name = field.name3
-          ..lambda = true
-          ..body = refer(field.stateFieldName).code,
-      );
+    (b) => b
+      ..docs.addAll(['']) // A new line
+      ..type = MethodType.getter
+      ..annotations.add(refer('override'))
+      ..returns = refer(field.type.getDisplayString())
+      ..name = field.name
+      ..lambda = true
+      ..body = refer(field.stateFieldName).code,
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_getter_method.dart
@@ -1,13 +1,10 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
-/// A mapper that converts a [MethodElement] into an event [Method]
+/// A mapper that converts a [MethodElement2] into an event [Method]
 class _StateGetterMethod implements _BuilderContract {
   const _StateGetterMethod(this.field);
 
-  final FieldElement field;
+  final FieldElement2 field;
 
   @override
   Method build() => Method(
@@ -15,8 +12,8 @@ class _StateGetterMethod implements _BuilderContract {
           ..docs.addAll(['']) // A new line
           ..type = MethodType.getter
           ..annotations.add(refer('override'))
-          ..returns = refer(field.type.getDisplayString(withNullability: true))
-          ..name = field.name
+          ..returns = refer(field.type.getDisplayString())
+          ..name = field.name3
           ..lambda = true
           ..body = refer(field.stateFieldName).code,
       );

--- a/packages/rx_bloc_generator/lib/src/builders/state_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_method.dart
@@ -1,20 +1,17 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
-/// A mapper that converts a [MethodElement] into an event [Method]
+/// A mapper that converts a [MethodElement2] into an event [Method]
 class _StateMethod implements _BuilderContract {
   const _StateMethod(this.field);
 
-  final FieldElement field;
+  final FieldElement2 field;
 
   @override
   Method build() => Method(
         (b) => b
           ..docs.addAll(['']) // A new line
           ..returns = refer(
-            field.type.getDisplayString(withNullability: true),
+            field.type.getDisplayString(),
           )
           ..name = field.stateMethodName,
       );

--- a/packages/rx_bloc_generator/lib/src/builders/state_method.dart
+++ b/packages/rx_bloc_generator/lib/src/builders/state_method.dart
@@ -1,18 +1,16 @@
 part of '../../rx_bloc_generator.dart';
 
-/// A mapper that converts a [MethodElement2] into an event [Method]
+/// A mapper that converts a [MethodElement] into an event [Method]
 class _StateMethod implements _BuilderContract {
   const _StateMethod(this.field);
 
-  final FieldElement2 field;
+  final FieldElement field;
 
   @override
   Method build() => Method(
-        (b) => b
-          ..docs.addAll(['']) // A new line
-          ..returns = refer(
-            field.type.getDisplayString(),
-          )
-          ..name = field.stateMethodName,
-      );
+    (b) => b
+      ..docs.addAll(['']) // A new line
+      ..returns = refer(field.type.getDisplayString())
+      ..name = field.stateMethodName,
+  );
 }

--- a/packages/rx_bloc_generator/lib/src/rx_bloc_generator_for_annotation.dart
+++ b/packages/rx_bloc_generator/lib/src/rx_bloc_generator_for_annotation.dart
@@ -9,13 +9,13 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
   /// If either the states or events class is missing the file is not generated.
   @override
   Future<String> generateForAnnotatedElement(
-    Element2 element,
+    Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
-    final classElement = element as ClassElement2;
+    final classElement = element as ClassElement;
 
-    final libraryReader = LibraryReader(classElement.library2);
+    final libraryReader = LibraryReader(classElement.library);
 
     try {
       return _BuildController(
@@ -27,8 +27,9 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
         //   void fetch();
         // }
         eventClass: libraryReader.classes.firstWhereOrNull(
-          (ClassElement2 classElement) => classElement.displayName
-              .contains(annotation.read('eventsClassName').stringValue),
+          (ClassElement classElement) => classElement.displayName.contains(
+            annotation.read('eventsClassName').stringValue,
+          ),
         ),
 
         /// Provides the states class as [ClassElement]
@@ -37,8 +38,9 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
         //   void fetch();
         // }
         stateClass: libraryReader.classes.firstWhereOrNull(
-          (classElement) => classElement.displayName
-              .contains(annotation.read('statesClassName').stringValue),
+          (classElement) => classElement.displayName.contains(
+            annotation.read('statesClassName').stringValue,
+          ),
         ),
       ).generate();
     } on _RxBlocGeneratorException catch (e) {
@@ -46,12 +48,18 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
       _logError(e.message);
       return '/**\n${e.message}\n*/';
     } on FormatterException catch (e) {
-      var message = e.errors.map((AnalysisError e) => e.message).join('\n');
+      var message = e.errors.map((e) => e.message).join('\n');
       // Format error
       _reportIssue(
         'FormatterException \n $message',
         libraryReader
-                .allElements.first.library2?.firstFragment.source.contents.data
+                .allElements
+                .first
+                .library
+                ?.firstFragment
+                .source
+                .contents
+                .data
                 .toString() ??
             '',
       );
@@ -61,7 +69,13 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
       _reportIssue(
         e.toString(),
         libraryReader
-                .allElements.first.library2?.firstFragment.source.contents.data
+                .allElements
+                .first
+                .library
+                ?.firstFragment
+                .source
+                .contents
+                .data
                 .toString() ??
             '',
       );

--- a/packages/rx_bloc_generator/lib/src/rx_bloc_generator_for_annotation.dart
+++ b/packages/rx_bloc_generator/lib/src/rx_bloc_generator_for_annotation.dart
@@ -1,8 +1,5 @@
 part of '../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
 /// The generator.
 class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
   /// Allows creating via `const` as well as enforces immutability here.
@@ -12,13 +9,13 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
   /// If either the states or events class is missing the file is not generated.
   @override
   Future<String> generateForAnnotatedElement(
-    Element element,
+    Element2 element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
-    final classElement = element as ClassElement;
+    final classElement = element as ClassElement2;
 
-    final libraryReader = LibraryReader(classElement.library);
+    final libraryReader = LibraryReader(classElement.library2);
 
     try {
       return _BuildController(
@@ -30,7 +27,7 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
         //   void fetch();
         // }
         eventClass: libraryReader.classes.firstWhereOrNull(
-          (ClassElement classElement) => classElement.displayName
+          (ClassElement2 classElement) => classElement.displayName
               .contains(annotation.read('eventsClassName').stringValue),
         ),
 
@@ -53,14 +50,20 @@ class RxBlocGeneratorForAnnotation extends GeneratorForAnnotation<RxBloc> {
       // Format error
       _reportIssue(
         'FormatterException \n $message',
-        libraryReader.allElements.first.source?.contents.data.toString() ?? '',
+        libraryReader
+                .allElements.first.library2?.firstFragment.source.contents.data
+                .toString() ??
+            '',
       );
       return '/**\n${e.message}\n*/';
     } on Exception catch (e) {
       // System error
       _reportIssue(
         e.toString(),
-        libraryReader.allElements.first.source?.contents.data.toString() ?? '',
+        libraryReader
+                .allElements.first.library2?.firstFragment.source.contents.data
+                .toString() ??
+            '',
       );
       return '/**\n$e\n*/';
     }

--- a/packages/rx_bloc_generator/lib/src/utilities/event_args_record.dart
+++ b/packages/rx_bloc_generator/lib/src/utilities/event_args_record.dart
@@ -3,7 +3,7 @@ part of '../../rx_bloc_generator.dart';
 class _EventArgsRecord {
   const _EventArgsRecord(this.method);
 
-  final MethodElement2 method;
+  final MethodElement method;
 
   /// The type of record used to wrap the method's parameters
   ///
@@ -27,10 +27,8 @@ class _EventArgsRecord {
   ///    ));
   /// }
   /// ```
-  Expression newInstanceWithParameters() => refer('').newInstance(
-        [],
-        _namedArguments(invocation: true),
-      );
+  Expression newInstanceWithParameters() =>
+      refer('').newInstance([], _namedArguments(invocation: true));
 
   /// Typedef for the record
   ///
@@ -39,21 +37,21 @@ class _EventArgsRecord {
   /// typedef _MultiplyNumbersEventArgs = ({int x, int y});
   /// ```
   Spec typeDef() => TypeDef(
-        (b) => b
-          ..docs.add('// ignore: unused_element')
-          ..name = _name
-          ..definition = recordType(),
-      );
+    (b) => b
+      ..docs.add('// ignore: unused_element')
+      ..name = _name
+      ..definition = recordType(),
+  );
 
-  String get _name => '_${method.name3?.capitalize()}EventArgs';
+  String get _name => '_${method.name?.capitalize()}EventArgs';
 
   Map<String, Reference> _namedArguments({bool invocation = false}) {
     var params = method.formalParameters;
 
     var namedArguments = <String, Reference>{};
     for (var param in params) {
-      namedArguments[param.name3 ?? ''] = invocation
-          ? refer(param.name3 ?? '')
+      namedArguments[param.name ?? ''] = invocation
+          ? refer(param.name ?? '')
           : refer(param.getTypeDisplayName());
     }
 

--- a/packages/rx_bloc_generator/lib/src/utilities/event_args_record.dart
+++ b/packages/rx_bloc_generator/lib/src/utilities/event_args_record.dart
@@ -1,12 +1,9 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
 class _EventArgsRecord {
   const _EventArgsRecord(this.method);
 
-  final MethodElement method;
+  final MethodElement2 method;
 
   /// The type of record used to wrap the method's parameters
   ///
@@ -48,15 +45,16 @@ class _EventArgsRecord {
           ..definition = recordType(),
       );
 
-  String get _name => '_${method.name.capitalize()}EventArgs';
+  String get _name => '_${method.name3?.capitalize()}EventArgs';
 
   Map<String, Reference> _namedArguments({bool invocation = false}) {
-    var params = method.parameters;
+    var params = method.formalParameters;
 
     var namedArguments = <String, Reference>{};
     for (var param in params) {
-      namedArguments[param.name] =
-          invocation ? refer(param.name) : refer(param.getTypeDisplayName());
+      namedArguments[param.name3 ?? ''] = invocation
+          ? refer(param.name3 ?? '')
+          : refer(param.getTypeDisplayName());
     }
 
     return namedArguments;

--- a/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
+++ b/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
@@ -1,8 +1,5 @@
 part of '../../rx_bloc_generator.dart';
 
-// ignore_for_file: deprecated_member_use
-// TODO: Remove the ignore once a new version of `source_gen` is released
-
 /// Supported types of streams
 class _BlocEventStreamTypes {
   /// Constants feel more comfortable than strings
@@ -32,15 +29,15 @@ extension _SpecExtensions on Spec {
       ).toString();
 }
 
-extension _StateFieldElement on FieldElement {
-  String get stateFieldName => '_${name}State';
+extension _StateFieldElement on FieldElement2 {
+  String get stateFieldName => '_${name3}State';
 
-  String get stateMethodName => '_mapTo${name.capitalize()}State';
+  String get stateMethodName => '_mapTo${name3?.capitalize()}State';
 }
 
-extension _EventMethodElement on MethodElement {
+extension _EventMethodElement on MethodElement2 {
   /// The event field name in the generated file
-  String get eventFieldName => '_\$${name}Event';
+  String get eventFieldName => '_\$${name3}Event';
 
   /// Is the the [RxBlocEvent.seed] annotation is provided
   bool get hasSeedAnnotation => RegExp(r'(?<=seed: ).*(?=\)|,)')
@@ -59,7 +56,8 @@ extension _EventMethodElement on MethodElement {
   /// the stream is not  [RxBlocEventType.behaviour]
   List<Expression> get seedPositionalArguments {
     if (hasSeedAnnotation && !isBehavior) {
-      throw _RxBlocGeneratorException('Event `$name` with type `PublishSubject`'
+      throw _RxBlocGeneratorException(
+          'Event `$name3` with type `PublishSubject`'
           ' can not have a `seed` parameter.');
     }
 
@@ -74,7 +72,7 @@ extension _EventMethodElement on MethodElement {
 
     if (seedArgumentsMatch.isEmpty) {
       throw _RxBlocGeneratorException(
-          'Event `$name` seed value is missing or is null.');
+          'Event `$name3` seed value is missing or is null.');
     }
 
     var seedArguments = seedArgumentsMatch.toString();
@@ -92,20 +90,18 @@ extension _EventMethodElement on MethodElement {
       : _BlocEventStreamTypes.publish;
 
   /// Provides the first annotation as [ElementAnnotation] if exists
-  ElementAnnotation? get _eventAnnotation => metadata.firstOrNull;
+  ElementAnnotation? get _eventAnnotation => metadata2.annotations.firstOrNull;
 
   /// Provides the [RxBlocEvent] annotation as [DartObject] if exists
   DartObject? get _computedRxBlocEventAnnotation =>
       _rxBlocEventAnnotation?.computeConstantValue();
 
   /// Provides the [RxBlocEvent] annotation as [ElementAnnotation] if exists
-  ElementAnnotation? get _rxBlocEventAnnotation => _eventAnnotation
-              ?.computeConstantValue()
-              ?.type
-              ?.getDisplayString(withNullability: true) ==
-          (RxBlocEvent).toString()
-      ? _eventAnnotation
-      : null;
+  ElementAnnotation? get _rxBlocEventAnnotation =>
+      _eventAnnotation?.computeConstantValue()?.type?.getDisplayString() ==
+              (RxBlocEvent).toString()
+          ? _eventAnnotation
+          : null;
 
   /// Is the event stream type a BehaviorSubject
   bool get isBehavior =>
@@ -120,9 +116,9 @@ extension _EventMethodElement on MethodElement {
     if (isUsingRecord) {
       return argsRecord.recordType().toRawDartCodeString();
     }
-    return parameters.isNotEmpty
+    return formalParameters.isNotEmpty
         // The only parameter's type
-        ? parameters.first.type.getDisplayString(withNullability: true)
+        ? formalParameters.first.type.getDisplayString()
         // Default type
         : 'void';
   }
@@ -135,8 +131,8 @@ extension _EventMethodElement on MethodElement {
   /// _${EventMethodName}EventName.add((param1: param1, param2: param2))
   ///
   Code buildBody() {
-    var requiredParams = parameters.whereRequired().clone();
-    var optionalParams = parameters.whereOptional().clone();
+    var requiredParams = formalParameters.whereRequired().clone();
+    var optionalParams = formalParameters.whereOptional().clone();
 
     if (requiredParams.isEmpty && optionalParams.isEmpty) {
       // Provide null if we don't have any parameters
@@ -162,9 +158,9 @@ extension _EventMethodElement on MethodElement {
       refer('$eventFieldName.add').call([argument]).code;
 }
 
-extension _EventMethodNamedRecordArgument on MethodElement {
+extension _EventMethodNamedRecordArgument on MethodElement2 {
   /// Indicates if a named record wrapper is generated for the parameters
-  bool get isUsingRecord => parameters.length > 1;
+  bool get isUsingRecord => formalParameters.length > 1;
 
   /// A named record wrapper for the method's parameters
   _EventArgsRecord get argsRecord {
@@ -173,17 +169,17 @@ extension _EventMethodNamedRecordArgument on MethodElement {
   }
 }
 
-extension _ListParameterElementWhere on List<ParameterElement> {
-  Iterable<ParameterElement> whereRequired() => where(
+extension _ListParameterElementWhere on List<FormalParameterElement> {
+  Iterable<FormalParameterElement> whereRequired() => where(
       (parameter) => !parameter.isNamed && !parameter.isOptionalPositional);
 
-  Iterable<ParameterElement> whereOptional() =>
+  Iterable<FormalParameterElement> whereOptional() =>
       where((parameter) => parameter.isOptionalPositional || parameter.isNamed);
 }
 
-extension _ListParameterElementClone on Iterable<ParameterElement> {
+extension _ListParameterElementClone on Iterable<FormalParameterElement> {
   List<Parameter> clone({bool toThis = false}) => map(
-        (ParameterElement parameter) => Parameter(
+        (FormalParameterElement parameter) => Parameter(
           (b) => b
             ..toThis = toThis
             ..required = parameter.isRequiredNamed
@@ -191,7 +187,7 @@ extension _ListParameterElementClone on Iterable<ParameterElement> {
                 ? Code(parameter.defaultValueCode ?? '')
                 : null
             ..named = parameter.isNamed
-            ..name = parameter.name
+            ..name = parameter.name3 ?? ''
             ..type = toThis
                 ? null // We don't need the type in the constructor
                 : refer(parameter.getTypeDisplayName()),
@@ -199,6 +195,6 @@ extension _ListParameterElementClone on Iterable<ParameterElement> {
       ).toList();
 }
 
-extension _ParameterElementToString on ParameterElement {
-  String getTypeDisplayName() => type.getDisplayString(withNullability: true);
+extension _ParameterElementToString on FormalParameterElement {
+  String getTypeDisplayName() => type.getDisplayString();
 }

--- a/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
+++ b/packages/rx_bloc_generator/lib/src/utilities/extensions.dart
@@ -19,29 +19,28 @@ extension _StringExtensions on String {
 /// It is the main [DartFormatter]
 extension _SpecExtensions on Spec {
   String toDartCodeString() => DartFormatter(
-        languageVersion: DartFormatter.latestLanguageVersion,
-      ).format(
-        toRawDartCodeString(),
-      );
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format(toRawDartCodeString());
 
   String toRawDartCodeString() => accept(
-        DartEmitter(allocator: Allocator.none, useNullSafetySyntax: true),
-      ).toString();
+    DartEmitter(allocator: Allocator.none, useNullSafetySyntax: true),
+  ).toString();
 }
 
-extension _StateFieldElement on FieldElement2 {
-  String get stateFieldName => '_${name3}State';
+extension _StateFieldElement on FieldElement {
+  String get stateFieldName => '_${name}State';
 
-  String get stateMethodName => '_mapTo${name3?.capitalize()}State';
+  String get stateMethodName => '_mapTo${name?.capitalize()}State';
 }
 
-extension _EventMethodElement on MethodElement2 {
+extension _EventMethodElement on MethodElement {
   /// The event field name in the generated file
-  String get eventFieldName => '_\$${name3}Event';
+  String get eventFieldName => '_\$${name}Event';
 
   /// Is the the [RxBlocEvent.seed] annotation is provided
-  bool get hasSeedAnnotation => RegExp(r'(?<=seed: ).*(?=\)|,)')
-      .hasMatch(_rxBlocEventAnnotation?.toSource() ?? '');
+  bool get hasSeedAnnotation => RegExp(
+    r'(?<=seed: ).*(?=\)|,)',
+  ).hasMatch(_rxBlocEventAnnotation?.toSource() ?? '');
 
   /// Provides the stream generic type
   ///
@@ -57,8 +56,9 @@ extension _EventMethodElement on MethodElement2 {
   List<Expression> get seedPositionalArguments {
     if (hasSeedAnnotation && !isBehavior) {
       throw _RxBlocGeneratorException(
-          'Event `$name3` with type `PublishSubject`'
-          ' can not have a `seed` parameter.');
+        'Event `$name` with type `PublishSubject`'
+        ' can not have a `seed` parameter.',
+      );
     }
 
     return [_seededArgument];
@@ -72,7 +72,8 @@ extension _EventMethodElement on MethodElement2 {
 
     if (seedArgumentsMatch.isEmpty) {
       throw _RxBlocGeneratorException(
-          'Event `$name3` seed value is missing or is null.');
+        'Event `$name` seed value is missing or is null.',
+      );
     }
 
     var seedArguments = seedArgumentsMatch.toString();
@@ -86,11 +87,11 @@ extension _EventMethodElement on MethodElement2 {
   /// Provides the stream type based on the [RxBlocEventType] annotation
   String get eventStreamType => isBehavior
       ? _BlocEventStreamTypes.behavior +
-          (hasSeedAnnotation ? '<$publishSubjectGenericType>' : '')
+            (hasSeedAnnotation ? '<$publishSubjectGenericType>' : '')
       : _BlocEventStreamTypes.publish;
 
   /// Provides the first annotation as [ElementAnnotation] if exists
-  ElementAnnotation? get _eventAnnotation => metadata2.annotations.firstOrNull;
+  ElementAnnotation? get _eventAnnotation => metadata.annotations.firstOrNull;
 
   /// Provides the [RxBlocEvent] annotation as [DartObject] if exists
   DartObject? get _computedRxBlocEventAnnotation =>
@@ -99,9 +100,9 @@ extension _EventMethodElement on MethodElement2 {
   /// Provides the [RxBlocEvent] annotation as [ElementAnnotation] if exists
   ElementAnnotation? get _rxBlocEventAnnotation =>
       _eventAnnotation?.computeConstantValue()?.type?.getDisplayString() ==
-              (RxBlocEvent).toString()
-          ? _eventAnnotation
-          : null;
+          (RxBlocEvent).toString()
+      ? _eventAnnotation
+      : null;
 
   /// Is the event stream type a BehaviorSubject
   bool get isBehavior =>
@@ -158,7 +159,7 @@ extension _EventMethodElement on MethodElement2 {
       refer('$eventFieldName.add').call([argument]).code;
 }
 
-extension _EventMethodNamedRecordArgument on MethodElement2 {
+extension _EventMethodNamedRecordArgument on MethodElement {
   /// Indicates if a named record wrapper is generated for the parameters
   bool get isUsingRecord => formalParameters.length > 1;
 
@@ -171,7 +172,8 @@ extension _EventMethodNamedRecordArgument on MethodElement2 {
 
 extension _ListParameterElementWhere on List<FormalParameterElement> {
   Iterable<FormalParameterElement> whereRequired() => where(
-      (parameter) => !parameter.isNamed && !parameter.isOptionalPositional);
+    (parameter) => !parameter.isNamed && !parameter.isOptionalPositional,
+  );
 
   Iterable<FormalParameterElement> whereOptional() =>
       where((parameter) => parameter.isOptionalPositional || parameter.isNamed);
@@ -179,20 +181,20 @@ extension _ListParameterElementWhere on List<FormalParameterElement> {
 
 extension _ListParameterElementClone on Iterable<FormalParameterElement> {
   List<Parameter> clone({bool toThis = false}) => map(
-        (FormalParameterElement parameter) => Parameter(
-          (b) => b
-            ..toThis = toThis
-            ..required = parameter.isRequiredNamed
-            ..defaultTo = parameter.defaultValueCode != null
-                ? Code(parameter.defaultValueCode ?? '')
-                : null
-            ..named = parameter.isNamed
-            ..name = parameter.name3 ?? ''
-            ..type = toThis
-                ? null // We don't need the type in the constructor
-                : refer(parameter.getTypeDisplayName()),
-        ),
-      ).toList();
+    (FormalParameterElement parameter) => Parameter(
+      (b) => b
+        ..toThis = toThis
+        ..required = parameter.isRequiredNamed
+        ..defaultTo = parameter.defaultValueCode != null
+            ? Code(parameter.defaultValueCode ?? '')
+            : null
+        ..named = parameter.isNamed
+        ..name = parameter.name ?? ''
+        ..type = toThis
+            ? null // We don't need the type in the constructor
+            : refer(parameter.getTypeDisplayName()),
+    ),
+  ).toList();
 }
 
 extension _ParameterElementToString on FormalParameterElement {

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rx_bloc_generator
 description: Code generator for rx_bloc that makes your BloC zero-boilerplate.
-version: 8.0.1
+version: 8.0.2
 repository: https://github.com/Prime-Holding/rx_bloc/tree/master/packages/rx_bloc_generator
 issue_tracker: https://github.com/Prime-Holding/rx_bloc/issues
 homepage: https://www.primeholding.com/

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=7.4.0 <8.0.0"
+  analyzer: ">=7.4.0 <9.0.0"
   build: ">=3.0.0 <5.0.0"
   code_builder: ^4.10.0
   collection: ^1.17.1

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=7.4.0 <9.0.0"
+  analyzer: ">=8.0.0 <10.0.0"
   build: ">=3.0.0 <5.0.0"
   code_builder: ^4.10.0
   collection: ^1.17.1

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -10,19 +10,19 @@ environment:
   sdk: ">=3.0.5 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.0.0 <8.0.0"
-  build: ^2.4.0
+  analyzer: ">=7.4.0 <8.0.0"
+  build: ">=3.0.0 <5.0.0"
   code_builder: ^4.10.0
   collection: ^1.17.1
   dart_style: ">=2.3.7 <4.0.0"
   logging: ^1.2.0
   rx_bloc: ^6.0.0
-  source_gen: ">=1.3.2 <3.0.0"
+  source_gen: ">=3.1.0 <5.0.0"
 
 dev_dependencies:
   build_runner: ^2.4.11
   clean_coverage: ^0.0.3
   coverage: ^1.7.2
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   source_gen_test: ^1.1.1
   test: ^1.25.8

--- a/packages/rx_bloc_generator/pubspec.yaml
+++ b/packages/rx_bloc_generator/pubspec.yaml
@@ -1,13 +1,13 @@
 name: rx_bloc_generator
 description: Code generator for rx_bloc that makes your BloC zero-boilerplate.
-version: 8.0.2
+version: 9.0.0
 repository: https://github.com/Prime-Holding/rx_bloc/tree/master/packages/rx_bloc_generator
 issue_tracker: https://github.com/Prime-Holding/rx_bloc/issues
 homepage: https://www.primeholding.com/
 topics: [codegen, build-runner]
 
 environment:
-  sdk: ">=3.0.5 <4.0.0"
+  sdk: ">=3.8.0 <4.0.0"
 
 dependencies:
   analyzer: ">=7.4.0 <8.0.0"

--- a/packages/rx_bloc_generator/test/src/rx_bloc_test.dart
+++ b/packages/rx_bloc_generator/test/src/rx_bloc_test.dart
@@ -350,8 +350,11 @@ typedef _WithPositionalAnd2OptionalEventArgs = ({int pp, int? op1, int? op2});
 typedef _WithPositionalAnd2NamedEventArgs = ({int pp, int? np1, int? np2});
 
 // ignore: unused_element
-typedef _WithPositionalAnd1Named1RequiredEventArgs =
-    ({int pp, int? np1, int np2});
+typedef _WithPositionalAnd1Named1RequiredEventArgs = ({
+  int pp,
+  int? np1,
+  int np2,
+});
 
 // ignore: unused_element
 typedef _WithTwoNamedRequiredEventArgs = ({int nr, bool nr2});
@@ -363,8 +366,10 @@ typedef _WithAnnotationAnd2PositionalEventArgs = ({int pp1, int pp2});
 typedef _WithSeededPositionalAndOptionalEventArgs = ({int pp, int? op});
 
 // ignore: unused_element
-typedef _WithSeededTwoPositionalOptionalDefaultNullEventArgs =
-    ({int? p1, int? p2});
+typedef _WithSeededTwoPositionalOptionalDefaultNullEventArgs = ({
+  int? p1,
+  int? p2,
+});
 
 // ignore: unused_element
 typedef _WithSeededTwoPositionalOptionalEventArgs = ({int? p1, int? p2});

--- a/packages/rx_bloc_test/analysis_options.yaml
+++ b/packages/rx_bloc_test/analysis_options.yaml
@@ -42,7 +42,6 @@ linter:
     - omit_local_variable_types
     - only_throw_errors
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     - prefer_adjacent_string_concatenation


### PR DESCRIPTION
#### Overview

> Closes: #1008

Projects using rx_bloc_generator often face dependency resolution failures when combined with other modern code generators (e.g., go_router_builder). Our previously strict version constraints for packages like build and source_gen prevented developers from upgrading their tooling.

This PR relaxes the version constraints in pubspec.yaml to allow for a wider range of compatible versions, improving interoperability within the Dart build ecosystem.

* Update the deps of rx_bloc_generator to the latest versions. 
* Update its code to use newer `analyzer` API specifications.

#### Checklist

*Implementation*
- [x] Implementation matches ticket acceptance criteria and technical notes
- [x] Manually tested against Acceptance Criteria
- [ ] UI checked in Light / Dark mode

*Stability*
- [x] Checked if changes affect any features and verified affected features work as expected
- [x] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [x] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [x] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [x] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes