### PR TITLE
Fix/1021 duplicated prompts create command

### DIFF
--- a/packages/rx_bloc/test/utils/rx_bloc_test.dart
+++ b/packages/rx_bloc/test/utils/rx_bloc_test.dart
@@ -7,6 +7,8 @@ import 'package:rx_bloc/rx_bloc.dart';
 import 'package:test/test.dart' as tester;
 import 'package:test/test.dart';
 
+void main() {}
+
 @isTest
 void rxBlocTest<B extends RxBlocTypeBase, StateOutputType>(
   String message, {

--- a/packages/rx_bloc_cli/CHANGELOG.md
+++ b/packages/rx_bloc_cli/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [6.0.1]
 * Remove mention of remote translation lookup from the README
+* Fix issue with interactive mode where arguments were read twice
 
 ## [6.0.0]
 Contains breaking changes

--- a/packages/rx_bloc_cli/lib/src/models/generator_arguments_provider.dart
+++ b/packages/rx_bloc_cli/lib/src/models/generator_arguments_provider.dart
@@ -31,8 +31,23 @@ class GeneratorArgumentsProvider {
   /// Performs necessary input validations
   GeneratorArguments readGeneratorArguments() {
     final projectConfiguration = _readProjectConfiguration();
-    final authConfiguration = _readAuthConfiguration();
-    final featureConfiguration = _readFeatureConfiguration(authConfiguration);
+
+    // Read onboarding and forgottenPassword once, as they are needed by both
+    // auth and feature configurations
+    final onboardingEnabled =
+        _reader.read<bool>(CreateCommandArguments.onboarding);
+    final forgottenPassword =
+        _reader.read<bool>(CreateCommandArguments.forgottenPassword);
+
+    final authConfiguration = _readAuthConfiguration(
+      onboardingEnabled: onboardingEnabled,
+      forgottenPassword: forgottenPassword,
+    );
+    final featureConfiguration = _readFeatureConfiguration(
+      authConfiguration: authConfiguration,
+      onboardingEnabled: onboardingEnabled,
+      forgottenPassword: forgottenPassword,
+    );
     final showcaseConfiguration = _readShowcaseConfiguration(
       authConfiguration,
       featureConfiguration,
@@ -71,7 +86,10 @@ class GeneratorArgumentsProvider {
 
   /// region Auth Configuration
 
-  AuthConfiguration _readAuthConfiguration() {
+  AuthConfiguration _readAuthConfiguration({
+    required bool onboardingEnabled,
+    required bool forgottenPassword,
+  }) {
     // Login
     var loginEnabled = _reader.read<bool>(CreateCommandArguments.login);
 
@@ -87,14 +105,6 @@ class GeneratorArgumentsProvider {
 
     // Multi-Factor Authentication
     final mfaEnabled = _reader.read<bool>(CreateCommandArguments.mfa);
-
-    // Onboarding/Registration
-    final onboardingEnabled =
-        _reader.read<bool>(CreateCommandArguments.onboarding);
-
-    // Forgotten Password
-    final forgottenPassword =
-        _reader.read<bool>(CreateCommandArguments.forgottenPassword);
 
     if (mfaEnabled && !otpEnabled) {
       _logger
@@ -129,8 +139,11 @@ class GeneratorArgumentsProvider {
 
   /// region Feature Configuration
 
-  FeatureConfiguration _readFeatureConfiguration(
-      AuthConfiguration authConfiguration) {
+  FeatureConfiguration _readFeatureConfiguration({
+    required AuthConfiguration authConfiguration,
+    required bool onboardingEnabled,
+    required bool forgottenPassword,
+  }) {
     // Change language
     final changeLanguageEnabled =
         _reader.read<bool>(CreateCommandArguments.changeLanguage);
@@ -162,18 +175,12 @@ class GeneratorArgumentsProvider {
     // Profile
     var profileEnabled = _reader.read<bool>(CreateCommandArguments.profile);
 
-    // Onboarding/Registration
-    var onboardingEnabled =
-        _reader.read<bool>(CreateCommandArguments.onboarding);
-
-    // Forgotten Password
-    final forgottenPassword =
-        _reader.read<bool>(CreateCommandArguments.forgottenPassword);
-
-    if (forgottenPassword && !onboardingEnabled) {
+    // Adjust onboarding based on forgottenPassword dependency
+    var adjustedOnboardingEnabled = onboardingEnabled;
+    if (forgottenPassword && !adjustedOnboardingEnabled) {
       _logger.warn(
           'Onboarding enabled, due to Forgotten Password feature requirement');
-      onboardingEnabled = true;
+      adjustedOnboardingEnabled = true;
     }
 
     // Authentication
@@ -200,7 +207,7 @@ class GeneratorArgumentsProvider {
       cicdGithubEnabled: cicdGithubEnabled,
       cicdCodemagicEnabled: cicdCodemagicEnabled,
       profileEnabled: profileEnabled,
-      onboardingEnabled: onboardingEnabled,
+      onboardingEnabled: adjustedOnboardingEnabled,
       forgottenPassword: forgottenPassword,
     );
   }

--- a/packages/rx_bloc_cli/test/models/generator_arguments_provider_test.dart
+++ b/packages/rx_bloc_cli/test/models/generator_arguments_provider_test.dart
@@ -155,5 +155,28 @@ void main() {
 
       verify(logger.warn(any)).called(4);
     });
+
+    test('should read each argument exactly once', () {
+      configureArgumentValues(Stub.defaultValues);
+
+      sut.readGeneratorArguments();
+
+      // Verify each argument that supports 
+      // interactive input is read exactly once
+      final interactiveArguments = CreateCommandArguments.values
+          .where((arg) => arg.supportsInteractiveInput);
+
+      for (final argument in interactiveArguments) {
+        verify(reader.read<Object>(
+          argument,
+          validation: anyNamed('validation'),
+        )).called(1);
+      }
+
+      verifyNever(reader.read<Object>(
+        CreateCommandArguments.interactive,
+        validation: anyNamed('validation'),
+      ));
+    });
   });
 }

--- a/packages/rx_bloc_cli/test/models/generator_arguments_provider_test.dart
+++ b/packages/rx_bloc_cli/test/models/generator_arguments_provider_test.dart
@@ -161,8 +161,7 @@ void main() {
 
       sut.readGeneratorArguments();
 
-      // Verify each argument that supports 
-      // interactive input is read exactly once
+      // Verify each argument that supports interactive input is read exactly once
       final interactiveArguments = CreateCommandArguments.values
           .where((arg) => arg.supportsInteractiveInput);
 

--- a/packages/rx_bloc_generator/test/src/rx_bloc_test.dart
+++ b/packages/rx_bloc_generator/test/src/rx_bloc_test.dart
@@ -11,6 +11,8 @@ import 'package:test/test.dart';
 
 part 'test_utilities.dart';
 
+void main() {}
+
 @ShouldGenerate(r'''
 part of 'rx_bloc_test.dart';
 
@@ -431,34 +433,19 @@ abstract class CounterBlocEvents {
   @RxBlocEvent(type: RxBlocEventType.behaviour, seed: 0)
   void withAnnotationAndPositional(int pp);
 
-  @RxBlocEvent(
-    type: RxBlocEventType.behaviour,
-    seed: (pp1: 1, pp2: 2),
-  )
+  @RxBlocEvent(type: RxBlocEventType.behaviour, seed: (pp1: 1, pp2: 2))
   void withAnnotationAnd2Positional(int pp1, int pp2);
 
-  @RxBlocEvent(
-    type: RxBlocEventType.behaviour,
-    seed: (pp: 1, op: 2),
-  )
+  @RxBlocEvent(type: RxBlocEventType.behaviour, seed: (pp: 1, op: 2))
   void withSeededPositionalAndOptional(int pp, [int? op]);
 
-  @RxBlocEvent(
-    type: RxBlocEventType.behaviour,
-    seed: (p1: null, p2: null),
-  )
+  @RxBlocEvent(type: RxBlocEventType.behaviour, seed: (p1: null, p2: null))
   void withSeededTwoPositionalOptionalDefaultNull([int? p1, int? p2]);
 
-  @RxBlocEvent(
-    type: RxBlocEventType.behaviour,
-    seed: (p1: 0, p2: 1),
-  )
+  @RxBlocEvent(type: RxBlocEventType.behaviour, seed: (p1: 0, p2: 1))
   void withSeededTwoPositionalOptional([int? p1, int? p2]);
 
-  @RxBlocEvent(
-    type: RxBlocEventType.behaviour,
-    seed: TestEnumParam.seed,
-  )
+  @RxBlocEvent(type: RxBlocEventType.behaviour, seed: TestEnumParam.seed)
   void withSeededPositionalEnum(TestEnumParam op);
 
   @RxBlocEvent(


### PR DESCRIPTION
#### Overview

> Closes: #1021 

This PR fixes an issue when running rx_bloc_cli create command, where some arguments were read twice

This PR also adds empty main methods in two files from rx_bloc and rx_bloc_generator, due to the test package requiring it, and since those files and with `_test.dart` which gets flaged as test.
> Require a function definition named main directly in a test suite and provide a more direct error message than a failing compiler output.
https://pub.dev/packages/test/changelog#1290

#### Checklist

*Implementation*
- [ ] Implementation matches ticket acceptance criteria and technical notes
- [ ] Manually tested against Acceptance Criteria
- [ ] UI checked in Light / Dark mode

*Stability*
- [ ] Checked if changes affect any features and verified affected features work as expected
- [x] Added unit tests for new code and verified existing tests work as expected

*Code quality*
- [x] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [ ] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
- [ ] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes