### PR TITLE
Fix incomplete GoRouter route path on generated feature

### DIFF
--- a/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/GenerateRxBlocFeatureAction.kt
+++ b/extensions/intellij/intellij_generator_plugin/src/main/java/com/primeholding/rxbloc_generator_plugin/action/GenerateRxBlocFeatureAction.kt
@@ -249,7 +249,7 @@ $newRoute""".trimIndent()
     
 //TODO move it the desired place in the routing tree Or make it as root route: @TypedGoRoute<${featureCamelCase}Route>(path: path) and run Build Runner - Build
 @immutable
-class ${featureCamelCase}Route extends GoRouteData implements RouteDataModel {
+class ${featureCamelCase}Route extends GoRouteData with $${featureCamelCase}Route implements RouteDataModel {
   const ${featureCamelCase}Route();
 
   @override

--- a/extensions/intellij/intellij_generator_plugin/src/test/resources/actions/GoRouterChanges/GenerateNewRoute.dart
+++ b/extensions/intellij/intellij_generator_plugin/src/test/resources/actions/GoRouterChanges/GenerateNewRoute.dart
@@ -1,6 +1,6 @@
 //TODO move it the desired place in the routing tree Or make it as root route: @TypedGoRoute<DevMenuRoute>(path: path) and run Build Runner - Build
 @immutable
-class DevMenuRoute extends GoRouteData implements RouteDataModel {
+class DevMenuRoute extends GoRouteData with $DevMenuRoute implements RouteDataModel {
   const DevMenuRoute();
 
   @override


### PR DESCRIPTION
#### Overview

> Closes: #1016 

This PR addresses an issues where the IntelliJ plugin would generate a feature with incomplete GoRouter route setup.

#### Checklist

*Implementation*
- [x] Implementation matches ticket acceptance criteria and technical notes
- [x] Manually tested against Acceptance Criteria
~- [ ] UI checked in Light / Dark mode~

*Stability*
- [ ] Checked if changes affect any features and verified affected features work as expected
~- [ ] Added unit tests for new code and verified existing tests work as expected~

*Code quality*
- [ ] Updated `CHANGELOG.md`, `README.md` and package versions in `pubspec.yaml`
- [x] Dependencies are updated to latest versions or new tickets are created if there are breaking changes or deprecations
~- [ ] If an unrelated part of the codebase needs to be updated or refactored, create tickets with proposed changes~